### PR TITLE
Feature/#22 bottom nav bar styling

### DIFF
--- a/app/(app)/guide/_layout.tsx
+++ b/app/(app)/guide/_layout.tsx
@@ -2,31 +2,35 @@ import { Tabs } from 'expo-router';
 import React from 'react';
 import { Platform, Pressable, View } from 'react-native';
 
-import { HapticTab } from '@/components/HapticTab';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 // symbols
+import { AntDesign, FontAwesome } from '@expo/vector-icons';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const GuideTabLayout: React.FC = () => {
   const colorScheme = useColorScheme();
-  
+  const { bottom } = useSafeAreaInsets();
   return (
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
-        tabBarButton: HapticTab,
+        tabBarButton: undefined,
         tabBarBackground: TabBarBackground,
         tabBarStyle: Platform.select({
           ios: {
             // Use a transparent background on iOS to show the blur effect
             position: 'absolute',
           },
-          default: {},
+          default: {
+            height: 70 + bottom,
+            paddingTop: 5,
+          },
         }),
       }}
     >
@@ -36,9 +40,9 @@ const GuideTabLayout: React.FC = () => {
           title: '홈',
           tabBarIcon: ({ focused, color }) =>
             focused ? (
-              <Ionicons name='home' size={28} color={color} />
+              <Ionicons name='home' size={26} color={color} />
             ) : (
-              <Ionicons name='home-outline' size={28} color={color} />
+              <Ionicons name='home-outline' size={26} color={color} />
             ),
         }}
       />
@@ -48,9 +52,9 @@ const GuideTabLayout: React.FC = () => {
           title: '내 상품',
           tabBarIcon: ({ focused, color }) =>
             focused ? (
-              <Ionicons name='search' size={28} color={color} />
+              <AntDesign name='product' size={26} color={color} />
             ) : (
-              <Ionicons name='search-outline' size={28} color={color} />
+              <AntDesign name='product' size={26} color={color} />
             ),
         }}
       />
@@ -75,12 +79,12 @@ const GuideTabLayout: React.FC = () => {
               <Pressable
                 {...filteredProps}
                 android_ripple={{ borderless: false, color: 'transparent' }}
-                className="-top-5 justify-center items-center"
+                className='-top-7 justify-center items-center'
               >
-                <View
-                  className="w-16 h-16 rounded-full bg-[#6C4CE9] justify-center items-center shadow-lg"
-                >
-                  {props.children}
+                <View className='w-20 h-20 rounded-full bg-[#a9c0ffa3] justify-center items-center shadow-lg'>
+                  <View className='w-16 h-16 rounded-full bg-[#6C4CE9] justify-center items-center shadow-lg'>
+                    {props.children}
+                  </View>
                 </View>
               </Pressable>
             );
@@ -91,12 +95,12 @@ const GuideTabLayout: React.FC = () => {
       <Tabs.Screen
         name='profile'
         options={{
-          title: '프로필',
+          title: '가이드',
           tabBarIcon: ({ focused, color }) =>
             focused ? (
-              <MaterialIcons name='favorite' size={28} color={color} />
+              <FontAwesome name='id-card' size={26} color={color} />
             ) : (
-              <MaterialIcons name='favorite-border' size={28} color={color} />
+              <FontAwesome name='id-card-o' size={26} color={color} />
             ),
         }}
       />
@@ -106,14 +110,14 @@ const GuideTabLayout: React.FC = () => {
           title: '마이',
           tabBarIcon: ({ focused, color }) =>
             focused ? (
-              <MaterialIcons name='person' size={28} color={color} />
+              <MaterialIcons name='person' size={26} color={color} />
             ) : (
-              <MaterialIcons name='person-outline' size={28} color={color} />
+              <MaterialIcons name='person-outline' size={26} color={color} />
             ),
         }}
       />
     </Tabs>
   );
-}
+};
 
 export default GuideTabLayout;

--- a/app/(app)/traveler/_layout.tsx
+++ b/app/(app)/traveler/_layout.tsx
@@ -2,7 +2,6 @@ import { Tabs } from 'expo-router';
 import React from 'react';
 import { Platform, Pressable, View } from 'react-native';
 
-import { HapticTab } from '@/components/HapticTab';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -11,22 +10,28 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
 const TravelerTabLayout: React.FC = () => {
   const colorScheme = useColorScheme();
-  
+  const { bottom } = useSafeAreaInsets();
+
   return (
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
-        tabBarButton: HapticTab,
+        tabBarButton: undefined,
         tabBarBackground: TabBarBackground,
         tabBarStyle: Platform.select({
           ios: {
             // Use a transparent background on iOS to show the blur effect
             position: 'absolute',
           },
-          default: {},
+          default: {
+            height: 70 + bottom,
+            paddingTop: 5,
+          },
         }),
       }}
     >
@@ -36,9 +41,9 @@ const TravelerTabLayout: React.FC = () => {
           title: '홈',
           tabBarIcon: ({ focused, color }) =>
             focused ? (
-              <Ionicons name='home' size={28} color={color} />
+              <Ionicons name='home' size={26} color={color} />
             ) : (
-              <Ionicons name='home-outline' size={28} color={color} />
+              <Ionicons name='home-outline' size={26} color={color} />
             ),
         }}
       />
@@ -48,9 +53,9 @@ const TravelerTabLayout: React.FC = () => {
           title: '검색',
           tabBarIcon: ({ focused, color }) =>
             focused ? (
-              <Ionicons name='search' size={28} color={color} />
+              <Ionicons name='search' size={26} color={color} />
             ) : (
-              <Ionicons name='search-outline' size={28} color={color} />
+              <Ionicons name='search-outline' size={26} color={color} />
             ),
         }}
       />
@@ -61,7 +66,7 @@ const TravelerTabLayout: React.FC = () => {
           tabBarIcon: ({ focused, color }) => (
             <MaterialIcons
               name={focused ? 'flight' : 'flight-takeoff'}
-              size={28}
+              size={26}
               color={'#fff'}
             />
           ),
@@ -75,12 +80,12 @@ const TravelerTabLayout: React.FC = () => {
               <Pressable
                 {...filteredProps}
                 android_ripple={{ borderless: false, color: 'transparent' }}
-                className="-top-5 justify-center items-center"
+                className='-top-7 justify-center items-center'
               >
-                <View
-                  className="w-16 h-16 rounded-full bg-[#6C4CE9] justify-center items-center shadow-lg"
-                >
-                  {props.children}
+                <View className='w-20 h-20 rounded-full bg-[#a9c0ffa3] justify-center items-center shadow-lg'>
+                  <View className='w-16 h-16 rounded-full bg-[#6C4CE9] justify-center items-center shadow-lg'>
+                    {props.children}
+                  </View>
                 </View>
               </Pressable>
             );
@@ -94,9 +99,9 @@ const TravelerTabLayout: React.FC = () => {
           title: '찜',
           tabBarIcon: ({ focused, color }) =>
             focused ? (
-              <MaterialIcons name='favorite' size={28} color={color} />
+              <MaterialIcons name='favorite' size={26} color={color} />
             ) : (
-              <MaterialIcons name='favorite-border' size={28} color={color} />
+              <MaterialIcons name='favorite-border' size={26} color={color} />
             ),
         }}
       />
@@ -106,14 +111,14 @@ const TravelerTabLayout: React.FC = () => {
           title: '프로필',
           tabBarIcon: ({ focused, color }) =>
             focused ? (
-              <MaterialIcons name='person' size={28} color={color} />
+              <MaterialIcons name='person' size={26} color={color} />
             ) : (
-              <MaterialIcons name='person-outline' size={28} color={color} />
+              <MaterialIcons name='person-outline' size={26} color={color} />
             ),
         }}
       />
     </Tabs>
   );
-}
+};
 
 export default TravelerTabLayout;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,6 +13,7 @@ import '../global.css';
 
 import { AuthProvider } from '@/contexts/AuthContext';
 import Toast from 'react-native-toast-message';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -26,16 +27,18 @@ export default function RootLayout() {
   }
 
   return (
-    <AuthProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name='(app)' options={{ headerShown: false }} />
-          <Stack.Screen name='login' options={{ headerShown: false }} />
-          <Stack.Screen name='+not-found' />
-        </Stack>
-        <StatusBar style='auto' />
-        <Toast />
-      </ThemeProvider>
-    </AuthProvider>
+    <SafeAreaProvider>
+      <AuthProvider>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack>
+            <Stack.Screen name='(app)' options={{ headerShown: false }} />
+            <Stack.Screen name='login' options={{ headerShown: false }} />
+            <Stack.Screen name='+not-found' />
+          </Stack>
+          <StatusBar style='auto' />
+          <Toast />
+        </ThemeProvider>
+      </AuthProvider>
+    </SafeAreaProvider>
   );
 }

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -3,7 +3,7 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#0a7ea4';
+const tintColorLight = '#613EEA';
 const tintColorDark = '#fff';
 
 export const Colors = {


### PR DESCRIPTION
## 이슈
- Closes #22 
## 변경 내용
- 가운데 여행 탭의 커스텀에 의한 다른 탭들의 아이콘 밀림 현상 해결
- 탭 선택시의 색상 오류 수정
- 가이드 탭의 탭 명 및 아이콘 변경
- 모바일 기기에 기본적으로 존재하는 내비게이션 바와의 중첩 방지 (safe-area-context 적용)
<img width="708" height="291" alt="image" src="https://github.com/user-attachments/assets/fd3ecbe0-94d4-45ae-af1d-bb482d5e02f2" />