### PR TITLE
Feature/#29 guide template api

### DIFF
--- a/api/auth.ts
+++ b/api/auth.ts
@@ -3,8 +3,6 @@
  * @module api/auth
  */
 
-import { login as kakaoLogin, logout as kakaoLogout } from '@react-native-seoul/kakao-login';
-
 import {
   AuthLoginRequest,
   AuthLoginResponse,
@@ -52,42 +50,9 @@ const signOut = async (): Promise<void> => {
   await apiClient.post<AuthLogoutResponse>('/auth/logout', undefined, { _retry: true } as any);
 };
 
-/**
- * 카카오 로그인을 시도하고 액세스 토큰을 반환합니다.
- * 
- * @returns {Promise<string>} 성공 시 액세스 토큰을 포함하는 Promise를 반환합니다.
- * @throws {Error} 로그인 과정에서 에러가 발생할 경우 'login error' 메시지를 포함한 에러를 발생시킵니다.
- */
-const kakaoSignIn = async (): Promise<string> => {
-  try {
-    const token = await kakaoLogin();
-    return token.accessToken;
-  }
-  catch (err) {
-    throw new Error('login error', { cause: err });
-  }
-};
-
-/**
- * 카카오 로그아웃을 시도합니다.
- * 
- * @returns {Promise<void>} 로그아웃 성공 시 Promise를 반환합니다.
- * @throws {Error} 로그아웃 과정에서 에러가 발생할 경우 'logout error' 메시지를 포함한 에러를 발생시킵니다.
- */
-const kakaoSignOut = async (): Promise<void> => {
-  try {
-    const msg = await kakaoLogout();
-  }
-  catch (err) {
-    throw new Error('logout error', { cause: err });
-  }
-};
-
 export const authApi = {
   reissue,
   signIn,
-  signOut,
-  kakaoSignIn,
-  kakaoSignOut,
+  signOut
 };
 

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -6,22 +6,22 @@
 import { login as kakaoLogin, logout as kakaoLogout } from '@react-native-seoul/kakao-login';
 
 import {
-  LoginRequest,
-  LoginResponse,
-  LogoutResponse,
-  ReissueRequest,
-  ReissueResponse
+  AuthLoginRequest,
+  AuthLoginResponse,
+  AuthLogoutResponse,
+  AuthReissueRequest,
+  AuthReissueResponse
 } from '@/types/auth';
 import apiClient from './client';
 
 /**
  * 리프레시 토큰을 사용하여 새로운 액세스 토큰을 재발급합니다.
  * @param {string} refreshToken - 재발급에 사용할 리프레시 토큰입니다.
- * @returns {Promise<ReissueResponse>} 성공 시 ReissueResponse를 반환합니다.
+ * @returns {Promise<AuthReissueResponse>} 성공 시 AuthReissueResponse를 반환합니다.
  */
-export const reissue = async (refreshToken: string): Promise<ReissueResponse> => {
-  const requestData: ReissueRequest = { refreshToken };
-  const response = await apiClient.post<ReissueResponse>(
+export const reissue = async (refreshToken: string): Promise<AuthReissueResponse> => {
+  const requestData: AuthReissueRequest = { refreshToken };
+  const response = await apiClient.post<AuthReissueResponse>(
     '/auth/reissue',
     requestData
   );
@@ -31,13 +31,13 @@ export const reissue = async (refreshToken: string): Promise<ReissueResponse> =>
 /**
  * 소셜 로그인을 통해 서버에 로그인을 시도하고, 성공 시 토큰 정보를 저장합니다.
  * @param {string} socialAccessToken - 소셜 로그인(카카오)을 통해 받은 액세스 토큰입니다.
- * @returns {Promise<LoginResponse | undefined>} 성공 시 LoginResponse를, 실패 시 undefined를 반환합니다.
+ * @returns {Promise<AuthLoginResponse | undefined>} 성공 시 AuthLoginResponse를, 실패 시 undefined를 반환합니다.
  */
 export const signIn = async (
   socialAccessToken: string
-): Promise<LoginResponse> => {
-  const requestData: LoginRequest = { socialAccessToken };
-  const response = await apiClient.post<LoginResponse>(
+): Promise<AuthLoginResponse> => {
+  const requestData: AuthLoginRequest = { socialAccessToken };
+  const response = await apiClient.post<AuthLoginResponse>(
     '/auth/login/KAKAO',
     requestData
   );
@@ -49,7 +49,7 @@ export const signIn = async (
  * @returns {Promise<void>}
  */
 export const signOut = async (): Promise<void> => {
-  await apiClient.post<LogoutResponse>('/auth/logout', undefined, { _retry: true } as any);
+  await apiClient.post<AuthLogoutResponse>('/auth/logout', undefined, { _retry: true } as any);
 };
 
 /**

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -19,7 +19,7 @@ import apiClient from './client';
  * @param {string} refreshToken - 재발급에 사용할 리프레시 토큰입니다.
  * @returns {Promise<AuthReissueResponse>} 성공 시 AuthReissueResponse를 반환합니다.
  */
-export const reissue = async (refreshToken: string): Promise<AuthReissueResponse> => {
+const reissue = async (refreshToken: string): Promise<AuthReissueResponse> => {
   const requestData: AuthReissueRequest = { refreshToken };
   const response = await apiClient.post<AuthReissueResponse>(
     '/auth/reissue',
@@ -33,7 +33,7 @@ export const reissue = async (refreshToken: string): Promise<AuthReissueResponse
  * @param {string} socialAccessToken - 소셜 로그인(카카오)을 통해 받은 액세스 토큰입니다.
  * @returns {Promise<AuthLoginResponse | undefined>} 성공 시 AuthLoginResponse를, 실패 시 undefined를 반환합니다.
  */
-export const signIn = async (
+const signIn = async (
   socialAccessToken: string
 ): Promise<AuthLoginResponse> => {
   const requestData: AuthLoginRequest = { socialAccessToken };
@@ -48,7 +48,7 @@ export const signIn = async (
  * 서버에서 로그아웃을 처리합니다.
  * @returns {Promise<void>}
  */
-export const signOut = async (): Promise<void> => {
+const signOut = async (): Promise<void> => {
   await apiClient.post<AuthLogoutResponse>('/auth/logout', undefined, { _retry: true } as any);
 };
 
@@ -83,5 +83,11 @@ const kakaoSignOut = async (): Promise<void> => {
   }
 };
 
-export { kakaoSignIn, kakaoSignOut };
+export const authApi = {
+  reissue,
+  signIn,
+  signOut,
+  kakaoSignIn,
+  kakaoSignOut,
+};
 

--- a/api/templates.ts
+++ b/api/templates.ts
@@ -1,0 +1,108 @@
+import { TemplateCreateRequest, TemplateCreateResponse, TemplateGetRequest, TemplateGetResponse, TemplateItinerary, TemplateSetContentRequest, TemplateSetContentResponse, TemplateSetImageUrlsRequest, TemplateSetImageUrlsResponse, TemplateSetItinerariesRequest, TemplateSetItinerariesResponse, TemplateSetRegionsRequest, TemplateSetRegionsResponse, TemplateSetTagsRequest, TemplateSetTagsResponse, TemplateSetTitleRequest, TemplateSetTitleResponse, TemplateUpdateRequest, TemplateUpdateResponse } from "@/types/templates";
+import apiClient from "./client";
+
+export const getTemplate = async (
+  id: number
+): Promise<TemplateGetResponse> => {
+  const requestData: TemplateGetRequest = {};
+  const response = await apiClient.get<TemplateGetResponse>(
+    `/templates/${id}`,
+    requestData
+  );
+  return response.data;
+};
+
+export const createTemplate = async (): Promise<TemplateCreateResponse> => {
+  const requestData: TemplateCreateRequest = {};
+  const response = await apiClient.post<TemplateCreateResponse>(
+    `/templates`,
+    requestData
+  );
+  return response.data;
+};
+
+export const updateTemplate = async (
+  id: number,
+  title: string,
+  content: string,
+  imageUrls: string[]
+): Promise<TemplateUpdateResponse> => {
+  const requestData: TemplateUpdateRequest = { title, content, imageUrls };
+  const response = await apiClient.put<TemplateUpdateResponse>(
+    `/templates/${id}`,
+    requestData
+  );
+  return response.data;
+};
+
+export const setTitle = async (
+  id: number,
+  title: string,
+): Promise<TemplateSetTitleResponse> => {
+  const requestData: TemplateSetTitleRequest = { title };
+  const response = await apiClient.patch<TemplateSetTitleResponse>(
+    `/templates/${id}/title`,
+    requestData
+  );
+  return response.data;
+};
+
+export const setContent = async (
+  id: number,
+  content: string,
+): Promise<TemplateSetContentResponse> => {
+  const requestData: TemplateSetContentRequest = { content };
+  const response = await apiClient.patch<TemplateSetContentResponse>(
+    `/templates/${id}/content`,
+    requestData
+  );
+  return response.data;
+};
+
+export const setImageUrls = async (
+  id: number,
+  imageUrls: string[],
+): Promise<TemplateSetImageUrlsResponse> => {
+  const requestData: TemplateSetImageUrlsRequest = { imageUrls };
+  const response = await apiClient.patch<TemplateSetImageUrlsResponse>(
+    `/templates/${id}/images`,
+    requestData
+  );
+  return response.data;
+};
+
+export const setTags = async (
+  id: number,
+  tagIds: number[]
+): Promise<TemplateSetTagsResponse> => {
+  const requestData: TemplateSetTagsRequest = { tagIds };
+  const response = await apiClient.patch<TemplateSetTagsResponse>(
+    `/templates/${id}/tags`,
+    requestData
+  );
+  return response.data;
+};
+
+export const setRegions = async (
+  id: number,
+  regionIds: number[]
+): Promise<TemplateSetRegionsResponse> => {
+  const requestData: TemplateSetRegionsRequest = { regionIds };
+  const response = await apiClient.patch<TemplateSetRegionsResponse>(
+    `/templates/${id}/regions`,
+    requestData
+  );
+  return response.data;
+};
+
+export const setItineraries = async (
+  id: number,
+  itineraries: TemplateItinerary[]
+): Promise<TemplateSetItinerariesResponse> => {
+  const requestData: TemplateSetItinerariesRequest = { itineraries };
+  const response = await apiClient.patch<TemplateSetItinerariesResponse>(
+    `/templates/${id}/itineraries`,
+    requestData
+  );
+  return response.data;
+};

--- a/api/templates.ts
+++ b/api/templates.ts
@@ -1,7 +1,7 @@
 import { TemplateCreateRequest, TemplateCreateResponse, TemplateGetRequest, TemplateGetResponse, TemplateItinerary, TemplateSetContentRequest, TemplateSetContentResponse, TemplateSetImageUrlsRequest, TemplateSetImageUrlsResponse, TemplateSetItinerariesRequest, TemplateSetItinerariesResponse, TemplateSetRegionsRequest, TemplateSetRegionsResponse, TemplateSetTagsRequest, TemplateSetTagsResponse, TemplateSetTitleRequest, TemplateSetTitleResponse, TemplateUpdateRequest, TemplateUpdateResponse } from "@/types/templates";
 import apiClient from "./client";
 
-export const getTemplate = async (
+const getTemplate = async (
   id: number
 ): Promise<TemplateGetResponse> => {
   const requestData: TemplateGetRequest = {};
@@ -12,7 +12,7 @@ export const getTemplate = async (
   return response.data;
 };
 
-export const createTemplate = async (): Promise<TemplateCreateResponse> => {
+const createTemplate = async (): Promise<TemplateCreateResponse> => {
   const requestData: TemplateCreateRequest = {};
   const response = await apiClient.post<TemplateCreateResponse>(
     `/templates`,
@@ -21,7 +21,7 @@ export const createTemplate = async (): Promise<TemplateCreateResponse> => {
   return response.data;
 };
 
-export const updateTemplate = async (
+const updateTemplate = async (
   id: number,
   title: string,
   content: string,
@@ -35,7 +35,7 @@ export const updateTemplate = async (
   return response.data;
 };
 
-export const setTitle = async (
+const setTitle = async (
   id: number,
   title: string,
 ): Promise<TemplateSetTitleResponse> => {
@@ -47,7 +47,7 @@ export const setTitle = async (
   return response.data;
 };
 
-export const setContent = async (
+const setContent = async (
   id: number,
   content: string,
 ): Promise<TemplateSetContentResponse> => {
@@ -59,7 +59,7 @@ export const setContent = async (
   return response.data;
 };
 
-export const setImageUrls = async (
+const setImageUrls = async (
   id: number,
   imageUrls: string[],
 ): Promise<TemplateSetImageUrlsResponse> => {
@@ -71,7 +71,7 @@ export const setImageUrls = async (
   return response.data;
 };
 
-export const setTags = async (
+const setTags = async (
   id: number,
   tagIds: number[]
 ): Promise<TemplateSetTagsResponse> => {
@@ -83,7 +83,7 @@ export const setTags = async (
   return response.data;
 };
 
-export const setRegions = async (
+const setRegions = async (
   id: number,
   regionIds: number[]
 ): Promise<TemplateSetRegionsResponse> => {
@@ -95,7 +95,7 @@ export const setRegions = async (
   return response.data;
 };
 
-export const setItineraries = async (
+const setItineraries = async (
   id: number,
   itineraries: TemplateItinerary[]
 ): Promise<TemplateSetItinerariesResponse> => {
@@ -105,4 +105,16 @@ export const setItineraries = async (
     requestData
   );
   return response.data;
+};
+
+export const templatesApi = {
+  getTemplate,
+  createTemplate,
+  updateTemplate,
+  setTitle,
+  setContent,
+  setImageUrls,
+  setTags,
+  setRegions,
+  setItineraries,
 };

--- a/api/users.ts
+++ b/api/users.ts
@@ -18,7 +18,7 @@ import apiClient from './client';
  * @param nickname - 설정할 새로운 닉네임
  * @returns 닉네임 설정 성공 시 응답 데이터를 반환합니다.
  */
-export const setNickname = async (
+const setNickname = async (
   nickname: string
 ): Promise<UserSetNicknameResponse> => {
   const requestData: UserSetNicknameRequest = { nickname };
@@ -34,7 +34,7 @@ export const setNickname = async (
  * @param tagIds - 설정할 태그 ID의 배열
  * @returns 태그 설정 성공 시 응답 데이터를 반환합니다.
  */
-export const setTags = async (tagIds: number[]): Promise<UserSetTagsResponse> => {
+const setTags = async (tagIds: number[]): Promise<UserSetTagsResponse> => {
   const requestData: UserSetTagsRequest = { tagIds };
   const response = await apiClient.patch<UserSetTagsResponse>(
     '/users/me/tags',
@@ -43,17 +43,24 @@ export const setTags = async (tagIds: number[]): Promise<UserSetTagsResponse> =>
   return response.data;
 };
 
-export const switchToGuide = async (): Promise<UserSwitchToGuideResponse> => {
+const switchToGuide = async (): Promise<UserSwitchToGuideResponse> => {
   const response = await apiClient.post<UserSwitchToGuideResponse>(
     '/users/me/switch-to-guide'
   );
   return response.data;
 };
 
-export const switchToTraveler = async (): Promise<UserSwitchToTravelerResponse> => {
+const switchToTraveler = async (): Promise<UserSwitchToTravelerResponse> => {
   const response = await apiClient.post<UserSwitchToTravelerResponse>(
     '/users/me/switch-to-traveler'
   );
   return response.data;
+};
+
+export const usersApi = {
+  setNickname,
+  setTags,
+  switchToGuide,
+  switchToTraveler,
 };
 

--- a/api/users.ts
+++ b/api/users.ts
@@ -4,12 +4,12 @@
  */
 
 import {
-  SetNicknameRequest,
-  SetNicknameResponse,
-  SetTagsRequest,
-  SetTagsResponse,
-  SwitchToGuideResponse,
-  SwitchToTravelerResponse
+  UserSetNicknameRequest,
+  UserSetNicknameResponse,
+  UserSetTagsRequest,
+  UserSetTagsResponse,
+  UserSwitchToGuideResponse,
+  UserSwitchToTravelerResponse
 } from '@/types/users';
 import apiClient from './client';
 
@@ -20,9 +20,9 @@ import apiClient from './client';
  */
 export const setNickname = async (
   nickname: string
-): Promise<SetNicknameResponse> => {
-  const requestData: SetNicknameRequest = { nickname };
-  const response = await apiClient.patch<SetNicknameResponse>(
+): Promise<UserSetNicknameResponse> => {
+  const requestData: UserSetNicknameRequest = { nickname };
+  const response = await apiClient.patch<UserSetNicknameResponse>(
     '/users/me/nickname',
     requestData
   );
@@ -34,24 +34,24 @@ export const setNickname = async (
  * @param tagIds - 설정할 태그 ID의 배열
  * @returns 태그 설정 성공 시 응답 데이터를 반환합니다.
  */
-export const setTags = async (tagIds: number[]): Promise<SetTagsResponse> => {
-  const requestData: SetTagsRequest = { tagIds };
-  const response = await apiClient.patch<SetTagsResponse>(
+export const setTags = async (tagIds: number[]): Promise<UserSetTagsResponse> => {
+  const requestData: UserSetTagsRequest = { tagIds };
+  const response = await apiClient.patch<UserSetTagsResponse>(
     '/users/me/tags',
     requestData
   );
   return response.data;
 };
 
-export const switchToGuide = async (): Promise<SwitchToGuideResponse> => {
-  const response = await apiClient.post<SwitchToGuideResponse>(
+export const switchToGuide = async (): Promise<UserSwitchToGuideResponse> => {
+  const response = await apiClient.post<UserSwitchToGuideResponse>(
     '/users/me/switch-to-guide'
   );
   return response.data;
 };
 
-export const switchToTraveler = async (): Promise<SwitchToTravelerResponse> => {
-  const response = await apiClient.post<SwitchToTravelerResponse>(
+export const switchToTraveler = async (): Promise<UserSwitchToTravelerResponse> => {
+  const response = await apiClient.post<UserSwitchToTravelerResponse>(
     '/users/me/switch-to-traveler'
   );
   return response.data;

--- a/app/login/set-interests.tsx
+++ b/app/login/set-interests.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 
-import { setTags } from '@/api/users';
+import { usersApi } from '@/api/users';
 import InterestTag from '@/components/InterestTag';
 import { INTEREST_TAGS } from '@/constants/Tags';
 import { router } from 'expo-router';
@@ -36,7 +36,7 @@ const SetInterestsScreen: React.FC = () => {
     }
     // 태그 변경 요청
     try {
-      await setTags(selectedTags);
+      await usersApi.setTags(selectedTags);
       router.replace('/(app)/traveler/home');
       return true;
     } catch (error) {

--- a/app/login/set-profile.tsx
+++ b/app/login/set-profile.tsx
@@ -1,4 +1,4 @@
-import { setNickname } from '@/api/users';
+import { usersApi } from '@/api/users';
 import { useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { Image, Text, TextInput, TouchableOpacity, View } from 'react-native';
@@ -32,7 +32,7 @@ const SetProfileScreen: React.FC = () => {
     }
     // 닉네임 변경 요청
     try {
-      await setNickname(name);
+      await usersApi.setNickname(name);
       router.push('/login/set-interests');
       return true;
     } catch (error) {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ import { setupInterceptors } from '@/api/client';
 import { usersApi } from '@/api/users';
 import { clearTokens, getTokens, saveTokens } from '@/lib/tokenStorage';
 import { reissueToken } from '@/services/auth';
+import { kakaoSignIn, kakaoSignOut } from '@/services/kakaoAuth';
 import { AuthContextType, AuthDecodedToken } from '@/types/auth';
 import { UserRole } from '@/types/users';
 import axios from 'axios';
@@ -46,7 +47,7 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
     setIsLoading(true);
     try {
       await authApi.signOut();
-      await authApi.kakaoSignOut();
+      await kakaoSignOut();
     } catch (error) {
       if (!(axios.isAxiosError(error) && error.response?.status === 401)) {
         console.error('Sign-out error:', error);
@@ -93,7 +94,7 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
   const signInHandler = useCallback(async () => {
     setIsLoading(true);
     try {
-      const socialAccessToken = await authApi.kakaoSignIn();
+      const socialAccessToken = await kakaoSignIn();
       const response = await authApi.signIn(socialAccessToken);
 
       if (response.data) {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -2,9 +2,9 @@
  * @file AuthContext.tsx
  * @description 인증 관련 컨텍스트와 프로바이더, 커스텀 훅을 제공하는 파일입니다.
  */
-import { kakaoSignIn, kakaoSignOut, signIn, signOut } from '@/api/auth';
+import { authApi } from '@/api/auth';
 import { setupInterceptors } from '@/api/client';
-import { switchToGuide, switchToTraveler } from '@/api/users';
+import { usersApi } from '@/api/users';
 import { clearTokens, getTokens, saveTokens } from '@/lib/tokenStorage';
 import { reissueToken } from '@/services/auth';
 import { AuthContextType, AuthDecodedToken } from '@/types/auth';
@@ -45,8 +45,8 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
   const signOutHandler = useCallback(async () => {
     setIsLoading(true);
     try {
-      await signOut();
-      await kakaoSignOut();
+      await authApi.signOut();
+      await authApi.kakaoSignOut();
     } catch (error) {
       if (!(axios.isAxiosError(error) && error.response?.status === 401)) {
         console.error('Sign-out error:', error);
@@ -93,8 +93,8 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
   const signInHandler = useCallback(async () => {
     setIsLoading(true);
     try {
-      const socialAccessToken = await kakaoSignIn();
-      const response = await signIn(socialAccessToken);
+      const socialAccessToken = await authApi.kakaoSignIn();
+      const response = await authApi.signIn(socialAccessToken);
 
       if (response.data) {
         const { accessToken, refreshToken, isNewUser } = response.data;
@@ -121,8 +121,8 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
     setIsLoading(true);
     try {
       const response = newUserRole === 'traveler'
-        ? await switchToTraveler()
-        : await switchToGuide();
+        ? await usersApi.switchToTraveler()
+        : await usersApi.switchToGuide();
 
       if (response && response.code === 200 && response.data) {
         const { accessToken, refreshToken } = response.data;

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -7,7 +7,7 @@ import { setupInterceptors } from '@/api/client';
 import { switchToGuide, switchToTraveler } from '@/api/users';
 import { clearTokens, getTokens, saveTokens } from '@/lib/tokenStorage';
 import { reissueToken } from '@/services/auth';
-import { AuthContextType, DecodedTokenType } from '@/types/auth';
+import { AuthContextType, AuthDecodedToken } from '@/types/auth';
 import { UserRole } from '@/types/users';
 import axios from 'axios';
 import { jwtDecode } from 'jwt-decode';
@@ -75,7 +75,7 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
     setAccessToken(accessToken);
 
     try {
-      const decodedToken = jwtDecode<DecodedTokenType>(accessToken);
+      const decodedToken = jwtDecode<AuthDecodedToken>(accessToken);
       if (decodedToken.role) {
         const role = decodedToken.role.toLowerCase() as UserRole;
         setUserRole(role);

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -3,7 +3,7 @@
  * @module services/auth
  */
 
-import { reissue } from '@/api/auth';
+import { authApi } from '@/api/auth';
 import { clearTokens, getTokens, saveTokens } from '@/lib/tokenStorage';
 import axios from 'axios';
 
@@ -21,7 +21,7 @@ export const reissueToken = async (): Promise<string | undefined> => {
       throw new Error('사용 가능한 리프레시 토큰이 없습니다.');
     }
 
-    const response = await reissue(refreshToken);
+    const response = await authApi.reissue(refreshToken);
 
     if (!response.data) {
       throw new Error('토큰 재발급 응답에 데이터가 없습니다.');

--- a/services/kakaoAuth.ts
+++ b/services/kakaoAuth.ts
@@ -1,0 +1,32 @@
+import { login as kakaoLogin, logout as kakaoLogout } from '@react-native-seoul/kakao-login';
+
+/**
+ * 카카오 로그인을 시도하고 액세스 토큰을 반환합니다.
+ * 
+ * @returns {Promise<string>} 성공 시 액세스 토큰을 포함하는 Promise를 반환합니다.
+ * @throws {Error} 로그인 과정에서 에러가 발생할 경우 'login error' 메시지를 포함한 에러를 발생시킵니다.
+ */
+export const kakaoSignIn = async (): Promise<string> => {
+  try {
+    const token = await kakaoLogin();
+    return token.accessToken;
+  }
+  catch (err) {
+    throw new Error('login error', { cause: err });
+  }
+};
+
+/**
+ * 카카오 로그아웃을 시도합니다.
+ * 
+ * @returns {Promise<void>} 로그아웃 성공 시 Promise를 반환합니다.
+ * @throws {Error} 로그아웃 과정에서 에러가 발생할 경우 'logout error' 메시지를 포함한 에러를 발생시킵니다.
+ */
+export const kakaoSignOut = async (): Promise<void> => {
+  try {
+    const msg = await kakaoLogout();
+  }
+  catch (err) {
+    throw new Error('logout error', { cause: err });
+  }
+};

--- a/services/users.ts
+++ b/services/users.ts
@@ -3,7 +3,7 @@
  * @module services/users
  */
 
-import { switchToGuide as apiSwitchToGuide, switchToTraveler as apiSwitchToTraveler } from '@/api/users';
+import { usersApi } from '@/api/users';
 import { saveTokens } from '@/lib/tokenStorage';
 import { UserSwitchToGuideResponse, UserSwitchToTravelerResponse } from '@/types/users';
 import axios from 'axios';
@@ -50,7 +50,7 @@ const handleRoleSwitch = async (
  * @returns 성공 시 API 응답 데이터를, 실패 시 undefined를 반환합니다.
  */
 export const switchRoleToGuide = async () => {
-  return handleRoleSwitch(apiSwitchToGuide, '가이드');
+  return handleRoleSwitch(usersApi.switchToGuide, '가이드');
 };
 
 /**
@@ -58,5 +58,5 @@ export const switchRoleToGuide = async () => {
  * @returns 성공 시 API 응답 데이터를, 실패 시 undefined를 반환합니다.
  */
 export const switchRoleToTraveler = async () => {
-  return handleRoleSwitch(apiSwitchToTraveler, '여행자');
+  return handleRoleSwitch(usersApi.switchToTraveler, '여행자');
 };

--- a/services/users.ts
+++ b/services/users.ts
@@ -5,11 +5,11 @@
 
 import { switchToGuide as apiSwitchToGuide, switchToTraveler as apiSwitchToTraveler } from '@/api/users';
 import { saveTokens } from '@/lib/tokenStorage';
-import { SwitchToGuideResponse, SwitchToTravelerResponse } from '@/types/users';
+import { UserSwitchToGuideResponse, UserSwitchToTravelerResponse } from '@/types/users';
 import axios from 'axios';
 
 // API 응답 타입의 공통 부분을 포함하는 유니온 타입 정의
-type RoleSwitchApiResponse = SwitchToGuideResponse | SwitchToTravelerResponse;
+type RoleSwitchApiResponse = UserSwitchToGuideResponse | UserSwitchToTravelerResponse;
 
 /**
  * 역할 전환의 공통 로직을 처리하는 헬퍼 함수입니다.

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,34 +1,29 @@
 import APIResponse from "./apiResponse";
 import { UserRole } from "./users";
 
-interface LoginRequest {
+interface AuthLoginRequest {
   socialAccessToken: string;
 }
-
-interface LoginResponse extends APIResponse<LoginData> {}
-
-interface LogoutRequest {
-  accessToken: string;
-}
-
-interface LogoutResponse extends APIResponse<null> {}
-
-interface LoginData {
+interface AuthLoginData {
   accessToken: string;
   refreshToken: string;
   isNewUser: boolean;
 }
+interface AuthLoginResponse extends APIResponse<AuthLoginData> {}
 
-interface ReissueRequest {
+interface AuthLogoutRequest {
+  accessToken: string;
+}
+interface AuthLogoutResponse extends APIResponse<null> {}
+
+interface AuthReissueRequest {
   refreshToken: string;
 }
-
-interface ReissueResponse extends APIResponse<ReissueData> {}
-
-interface ReissueData {
+interface AuthReissueData {
   accessToken: string;
   refreshToken: string;
 }
+interface AuthReissueResponse extends APIResponse<AuthReissueData> {}
 
 interface AuthContextType {
   accessToken: string | null;
@@ -43,7 +38,7 @@ interface AuthContextType {
   switchUserRole: (newUserRole: UserRole) => Promise<void>;
 }
 
-interface DecodedTokenType {
+interface AuthDecodedToken {
   exp: string;
   iat: string;
   role: 'GUIDE' | 'TRAVELER';
@@ -51,5 +46,16 @@ interface DecodedTokenType {
   userId: number;
 }
 
-export { AuthContextType, DecodedTokenType, LoginRequest, LoginResponse, LogoutRequest, LogoutResponse, ReissueRequest, ReissueResponse };
+export {
+  AuthContextType,
+  AuthDecodedToken,
+  AuthLoginData,
+  AuthLoginRequest,
+  AuthLoginResponse,
+  AuthLogoutRequest,
+  AuthLogoutResponse,
+  AuthReissueData,
+  AuthReissueRequest,
+  AuthReissueResponse,
+};
 

--- a/types/templates.ts
+++ b/types/templates.ts
@@ -1,0 +1,95 @@
+import APIResponse from "./apiResponse";
+
+interface Itinerary {
+  day: number;
+  title: string;
+  content: string;
+  startTime: string;
+  latitude: number;
+  longitude: number;
+}
+
+interface GetTemplateRequest {}
+interface GetTemplateData {
+  title: string;
+  content: string;
+  regionNames: string[];
+  tagNames: string[];
+  imageUrls: string[];
+}
+interface GetTemplateResponse extends APIResponse<GetTemplateData> {}
+
+interface CreateTemplateRequest {}
+interface CreateTemplateData {
+  templateId: number;
+}
+interface CreateTemplateResponse extends APIResponse<CreateTemplateData> {}
+
+interface SetTemplateRequest {
+  title: string;
+  content: string;
+  imageUrls: string[];
+}
+interface SetTemplateData {}
+interface SetTemplateResponse extends APIResponse<SetTemplateData> {}
+
+interface SetTitleRequest {
+  title: string;
+}
+interface SetTitleData {
+  title: string;
+}
+interface SetTitleResponse extends APIResponse<SetTitleData> {}
+
+interface SetContentRequest {
+  content: string;
+}
+interface SetContentData {
+  content: string;
+}
+interface SetContentResponse extends APIResponse<SetContentData> {}
+
+interface SetImageUrlsRequest {
+  imageUrls: string[];
+}
+interface SetImageUrlsData {
+  imageUrls: string[];
+}
+interface SetImageUrlsResponse extends APIResponse<SetImageUrlsData> {}
+
+interface TemplateSetTagsResponse {
+  tagIds: number[];
+}
+interface TemplateSetTagsData {
+  tagNames: string[];
+}
+interface TemplateSetTagsRequest extends APIResponse<TemplateSetTagsData> {}
+
+interface SetRegionsRequest {
+  regionIds: number[];
+}
+interface SetRegionsData {
+  regionNames: string[];
+}
+interface SetRegionsResponse extends APIResponse<SetRegionsData> {}
+
+interface SetItinerariesRequest {
+  itineraries: Itinerary[];
+}
+interface SetItinerariesData {}
+interface SetItinerariesResponse extends APIResponse<SetItinerariesData> {}
+
+export {
+  CreateTemplateRequest,
+  CreateTemplateResponse, GetTemplateRequest,
+  GetTemplateResponse, Itinerary, SetContentRequest,
+  SetContentResponse,
+  SetImageUrlsRequest,
+  SetImageUrlsResponse, SetItinerariesRequest,
+  SetItinerariesResponse, SetRegionsRequest,
+  SetRegionsResponse, SetTemplateRequest,
+  SetTemplateResponse,
+  SetTitleRequest,
+  SetTitleResponse, TemplateSetTagsRequest,
+  TemplateSetTagsResponse
+};

--- a/types/templates.ts
+++ b/types/templates.ts
@@ -1,6 +1,9 @@
 import APIResponse from "./apiResponse";
 
-interface Itinerary {
+/**
+ * 템플릿의 여행 일정 정보를 나타냅니다.
+ */
+interface TemplateItinerary {
   day: number;
   title: string;
   content: string;
@@ -9,87 +12,110 @@ interface Itinerary {
   longitude: number;
 }
 
-interface GetTemplateRequest {}
-interface GetTemplateData {
+interface TemplateGetRequest {}
+interface TemplateGetData {
   title: string;
   content: string;
   regionNames: string[];
   tagNames: string[];
   imageUrls: string[];
 }
-interface GetTemplateResponse extends APIResponse<GetTemplateData> {}
+interface TemplateGetResponse extends APIResponse<TemplateGetData> {}
 
-interface CreateTemplateRequest {}
-interface CreateTemplateData {
+interface TemplateCreateRequest {}
+interface TemplateCreateData {
   templateId: number;
 }
-interface CreateTemplateResponse extends APIResponse<CreateTemplateData> {}
+interface TemplateCreateResponse extends APIResponse<TemplateCreateData> {}
 
-interface SetTemplateRequest {
+/**
+ * 템플릿의 여러 정보를 한 번에 수정합니다.
+ */
+interface TemplateUpdateRequest {
   title: string;
   content: string;
   imageUrls: string[];
 }
-interface SetTemplateData {}
-interface SetTemplateResponse extends APIResponse<SetTemplateData> {}
+interface TemplateUpdateData {}
+interface TemplateUpdateResponse extends APIResponse<TemplateUpdateData> {}
 
-interface SetTitleRequest {
+interface TemplateSetTitleRequest {
   title: string;
 }
-interface SetTitleData {
+interface TemplateSetTitleData {
   title: string;
 }
-interface SetTitleResponse extends APIResponse<SetTitleData> {}
+interface TemplateSetTitleResponse extends APIResponse<TemplateSetTitleData> {}
 
-interface SetContentRequest {
+interface TemplateSetContentRequest {
   content: string;
 }
-interface SetContentData {
+interface TemplateSetContentData {
   content: string;
 }
-interface SetContentResponse extends APIResponse<SetContentData> {}
+interface TemplateSetContentResponse extends APIResponse<TemplateSetContentData> {}
 
-interface SetImageUrlsRequest {
+interface TemplateSetImageUrlsRequest {
   imageUrls: string[];
 }
-interface SetImageUrlsData {
+interface TemplateSetImageUrlsData {
   imageUrls: string[];
 }
-interface SetImageUrlsResponse extends APIResponse<SetImageUrlsData> {}
+interface TemplateSetImageUrlsResponse extends APIResponse<TemplateSetImageUrlsData> {}
 
-interface TemplateSetTagsResponse {
+/**
+ * 템플릿의 태그를 설정합니다.
+ */
+interface TemplateSetTagsRequest {
   tagIds: number[];
 }
 interface TemplateSetTagsData {
   tagNames: string[];
 }
-interface TemplateSetTagsRequest extends APIResponse<TemplateSetTagsData> {}
+interface TemplateSetTagsResponse extends APIResponse<TemplateSetTagsData> {}
 
-interface SetRegionsRequest {
+interface TemplateSetRegionsRequest {
   regionIds: number[];
 }
-interface SetRegionsData {
+interface TemplateSetRegionsData {
   regionNames: string[];
 }
-interface SetRegionsResponse extends APIResponse<SetRegionsData> {}
+interface TemplateSetRegionsResponse extends APIResponse<TemplateSetRegionsData> {}
 
-interface SetItinerariesRequest {
-  itineraries: Itinerary[];
+interface TemplateSetItinerariesRequest {
+  itineraries: TemplateItinerary[];
 }
-interface SetItinerariesData {}
-interface SetItinerariesResponse extends APIResponse<SetItinerariesData> {}
+interface TemplateSetItinerariesData {}
+interface TemplateSetItinerariesResponse extends APIResponse<TemplateSetItinerariesData> {}
 
 export {
-  CreateTemplateRequest,
-  CreateTemplateResponse, GetTemplateRequest,
-  GetTemplateResponse, Itinerary, SetContentRequest,
-  SetContentResponse,
-  SetImageUrlsRequest,
-  SetImageUrlsResponse, SetItinerariesRequest,
-  SetItinerariesResponse, SetRegionsRequest,
-  SetRegionsResponse, SetTemplateRequest,
-  SetTemplateResponse,
-  SetTitleRequest,
-  SetTitleResponse, TemplateSetTagsRequest,
-  TemplateSetTagsResponse
+  TemplateCreateData,
+  TemplateCreateRequest,
+  TemplateCreateResponse,
+  TemplateGetData,
+  TemplateGetRequest,
+  TemplateGetResponse,
+  TemplateItinerary,
+  TemplateSetContentData,
+  TemplateSetContentRequest,
+  TemplateSetContentResponse,
+  TemplateSetImageUrlsData,
+  TemplateSetImageUrlsRequest,
+  TemplateSetImageUrlsResponse,
+  TemplateSetItinerariesData,
+  TemplateSetItinerariesRequest,
+  TemplateSetItinerariesResponse,
+  TemplateSetRegionsData,
+  TemplateSetRegionsRequest,
+  TemplateSetRegionsResponse,
+  TemplateSetTagsData,
+  TemplateSetTagsRequest,
+  TemplateSetTagsResponse,
+  TemplateSetTitleData,
+  TemplateSetTitleRequest,
+  TemplateSetTitleResponse,
+  TemplateUpdateData,
+  TemplateUpdateRequest,
+  TemplateUpdateResponse
 };
+

--- a/types/users.ts
+++ b/types/users.ts
@@ -2,47 +2,44 @@ import APIResponse from "./apiResponse";
 
 type UserRole = 'traveler' | 'guide';
 
-interface SetNicknameRequest {
+interface UserSetNicknameRequest {
   nickname: string;
 }
-
-interface SetNicknameResponse extends APIResponse<SetNicknameData> {}
-
-interface SetNicknameData {
+interface UserSetNicknameData {
   nickname: string;
 }
+interface UserSetNicknameResponse extends APIResponse<UserSetNicknameData> {}
 
-interface SetTagsRequest {
+interface UserSetTagsRequest {
   tagIds: number[];
 }
-
-interface SetTagsData {
+interface UserSetTagsData {
   tagNames: string[];
 }
+interface UserSetTagsResponse extends APIResponse<UserSetTagsData> {}
 
-interface SetTagsResponse extends APIResponse<SetTagsData> {}
-
-interface SwitchToGuideRequest {}
-
-interface SwitchToGuideData {
+interface UserSwitchToGuideRequest {}
+interface UserSwitchToGuideData {
   accessToken: string;
   refreshToken: string;
 }
+interface UserSwitchToGuideResponse extends APIResponse<UserSwitchToGuideData> {}
 
-interface SwitchToGuideResponse extends APIResponse<SwitchToGuideData> {}
-
-type SwitchToTravelerRequest = SwitchToGuideRequest;
-type SwitchToTravelerResponse = SwitchToGuideResponse;
+type UserSwitchToTravelerRequest = UserSwitchToGuideRequest;
+type UserSwitchToTravelerResponse = UserSwitchToGuideResponse;
 
 export {
-  SetNicknameRequest,
-  SetNicknameResponse,
-  SetTagsRequest,
-  SetTagsResponse,
-  SwitchToGuideRequest,
-  SwitchToGuideResponse,
-  SwitchToTravelerRequest,
-  SwitchToTravelerResponse,
-  UserRole
+  UserRole,
+  UserSetNicknameData,
+  UserSetNicknameRequest,
+  UserSetNicknameResponse,
+  UserSetTagsData,
+  UserSetTagsRequest,
+  UserSetTagsResponse,
+  UserSwitchToGuideData,
+  UserSwitchToGuideRequest,
+  UserSwitchToGuideResponse,
+  UserSwitchToTravelerRequest,
+  UserSwitchToTravelerResponse,
 };
 


### PR DESCRIPTION
## 이슈
- Closes #29 

## 변경 내용
- templates 관련 API 함수 추가
- 이름 충돌을 방지하기 위해 새 네이밍 커벤션 적용
- 카카오 로그인 관련 함수 /services로 이동

## 상세
- /api 내의 모듈들은 함수들을 담은 object를 export 하게 바뀌었습니다.
``` javascript
// /api/auth.ts 모듈 임포트
import { authApi } from '@/api/auth';
...
// /api/auth.ts 모듈 내의 signOut 함수 호출
authApi.signOut();
```
- 백엔드 API와 소통하는 로직만 담당하는 /api 에 카카오 로그인 함수는 적합하지 않다고 판단했습니다.
따라서 /services 로 옮기게 되었습니다.
## 기타
