### PR TITLE
Fix/#33 bug token reissue

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -39,6 +39,10 @@ apiClient.interceptors.request.use(
     const tokens = await getTokens();
     const accessToken = tokens.accessToken;
 
+    // 토큰 재발급 API에서 액세스 토큰을 검증하는 로직을 회피합니다.
+    if (config.url === '/auth/reissue') {
+      config.headers.Authorization = undefined;
+    }
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }

--- a/api/client.ts
+++ b/api/client.ts
@@ -60,6 +60,12 @@ export const setupInterceptors = (
     (response) => response,
     async (error) => {
       const originalRequest = error.config as CustomInternalAxiosRequestConfig;
+
+      // 토큰 재발급 요청 자체에서 발생한 401은 무시하여 무한 루프를 방지합니다.
+      if (originalRequest.url === '/auth/reissue') {
+        return Promise.reject(error);
+      }
+
       if (error.response?.status === 401 && !originalRequest._retry) {
         originalRequest._retry = true;
         console.warn('액세스 토큰 만료, 토큰 재발급 시도 중...');


### PR DESCRIPTION
## 이슈
- Closes #33  

## 변경 내용
- 토큰 재발급 과정에서 발생하는 무한 루프 방지 코드 삽입
- 토큰 재발급 API에 요청 시 Bearer Token 보내지 않도록 수정 

## 기타
자세한 사항은 #33 참고하시면 됩니다.