### PR TITLE
Feature/#71 improve template screen

### DIFF
--- a/app/(app)/guide/session/[id]/session-room.tsx
+++ b/app/(app)/guide/session/[id]/session-room.tsx
@@ -183,7 +183,7 @@ const SessionRoomContent: React.FC = () => {
                   </Text>
                 </View>
                 <View style={styles.itineraryContent}>
-                  <Text style={styles.itineraryTitle}>{item.title}</Text>
+                  <Text style={styles.itineraryTitle}>{item.location}</Text>
                   {item.content ? (
                     <Text style={styles.itineraryDescription}>
                       {item.content}

--- a/app/(app)/guide/session/index.tsx
+++ b/app/(app)/guide/session/index.tsx
@@ -96,7 +96,9 @@ const GuideTripListScreen: React.FC = () => {
       <View className='flex-1 bg-gray-50'>
         {/* 헤더 */}
         <View className='bg-white pt-6 pb-4 px-6'>
-          <Text className='text-3xl font-bold text-gray-900'>나의 여행 목록</Text>
+          <Text className='text-3xl font-bold text-gray-900'>
+            나의 여행 목록
+          </Text>
         </View>
 
         {/* 현재 진행 중인 여행 섹션 */}
@@ -232,6 +234,7 @@ const GuideTripListScreen: React.FC = () => {
             </View>
           ) : (
             <GuideSessionList
+              userRole='GUIDE'
               sessions={filteredSessions}
               onEndReached={() => {
                 const statuses =

--- a/app/(app)/guide/template/[id]/edit-itineraries.tsx
+++ b/app/(app)/guide/template/[id]/edit-itineraries.tsx
@@ -60,8 +60,15 @@ const EditTemplateItinerariesScreen: React.FC = () => {
   const insets = useSafeAreaInsets();
 
   // useTemplateDetails 훅에서 여정 데이터 및 관리 함수들을 가져옵니다.
-  const { itineraries, day, deleteItinerary, addItinerary, setDay, isLoading } =
-    useTemplateDetails();
+  const {
+    itineraries,
+    day,
+    deleteItinerary,
+    addItinerary,
+    setDay,
+    isLoading,
+    addDay: appendDay,
+  } = useTemplateDetails();
 
   useFocusEffect(
     useCallback(() => {
@@ -141,6 +148,11 @@ const EditTemplateItinerariesScreen: React.FC = () => {
 
   const serializeItineraries = useCallback(
     (data: Record<number, TemplateItinerary[]>) => {
+      const days = Object.keys(data)
+        .map(Number)
+        .filter((value) => Number.isFinite(value))
+        .sort((a, b) => a - b);
+
       const flattened = flattenItineraries(data)
         .map((item) => ({
           ...item,
@@ -157,7 +169,7 @@ const EditTemplateItinerariesScreen: React.FC = () => {
           return (a.id ?? 0) - (b.id ?? 0);
         });
 
-      return JSON.stringify(flattened);
+      return JSON.stringify({ days, items: flattened });
     },
     []
   );
@@ -282,6 +294,11 @@ const EditTemplateItinerariesScreen: React.FC = () => {
     });
   };
 
+  const handleAddDay = () => {
+    appendDay();
+    setSelectedItineraryId(null);
+  };
+
   /**
    * 현재까지의 모든 일정 변경사항(추가, 수정, 삭제)을 서버에 일괄 저장합니다.
    */
@@ -401,6 +418,13 @@ const EditTemplateItinerariesScreen: React.FC = () => {
               </Text>
             </TouchableOpacity>
           ))}
+          <TouchableOpacity
+            style={[styles.dayButton, styles.addDayButton]}
+            onPress={handleAddDay}
+          >
+            <Ionicons name='add' size={16} color='#8130FF' />
+            <Text style={styles.addDayButtonText}>일차 추가</Text>
+          </TouchableOpacity>
         </ScrollView>
       </View>
       <Text style={styles.listTitle}>상세 일정</Text>
@@ -552,6 +576,18 @@ const styles = StyleSheet.create({
     borderColor: '#949494',
     borderWidth: 1,
     marginRight: 12,
+  },
+  addDayButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderColor: '#8130FF',
+    borderStyle: 'dashed',
+  },
+  addDayButtonText: {
+    fontSize: 16,
+    color: '#8130FF',
+    fontWeight: '600',
+    marginLeft: 6,
   },
   dayButtonActive: {
     backgroundColor: '#8130FF',

--- a/app/(app)/guide/template/[id]/edit-itineraries.tsx
+++ b/app/(app)/guide/template/[id]/edit-itineraries.tsx
@@ -14,10 +14,22 @@ import {
   CameraAnimationEasing,
   ClusterMarkerProp,
 } from '@mj-studio/react-native-naver-map';
-import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useFocusEffect,
+  useLocalSearchParams,
+  useNavigation,
+  useRouter,
+} from 'expo-router';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   ActivityIndicator,
+  Alert,
   ScrollView,
   StyleSheet,
   Text,
@@ -34,17 +46,21 @@ import Toast from 'react-native-toast-message';
  */
 const EditTemplateItinerariesScreen: React.FC = () => {
   const router = useRouter();
+  const navigation = useNavigation();
   const { id } = useLocalSearchParams<{ id: string }>();
   const [isSaving, setIsSaving] = useState(false);
   const [mapKey, setMapKey] = useState(0);
   const [selectedItineraryId, setSelectedItineraryId] = useState<number | null>(
     null
   );
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const mapViewRef = useRef<InteractiveMapViewRef>(null);
+  const initialItinerariesSnapshotRef = useRef<string | null>(null);
+  const allowNavigationRef = useRef(false);
   const insets = useSafeAreaInsets();
 
   // useTemplateDetails 훅에서 여정 데이터 및 관리 함수들을 가져옵니다.
-  const { itineraries, day, deleteItinerary, addItinerary, setDay } =
+  const { itineraries, day, deleteItinerary, addItinerary, setDay, isLoading } =
     useTemplateDetails();
 
   useFocusEffect(
@@ -66,10 +82,10 @@ const EditTemplateItinerariesScreen: React.FC = () => {
         zoom: 16,
         easing: 'EaseIn',
       });
-      
+
       return;
     }
-    
+
     if (itineraries[day].length === 1) {
       const firstItinerary = itineraries[day][0];
       mapViewRef.current?.animateCameraTo({
@@ -122,6 +138,78 @@ const EditTemplateItinerariesScreen: React.FC = () => {
       setSelectedItineraryId(clickedId);
     }
   };
+
+  const serializeItineraries = useCallback(
+    (data: Record<number, TemplateItinerary[]>) => {
+      const flattened = flattenItineraries(data)
+        .map((item) => ({
+          ...item,
+          startTime: item.startTime ?? '',
+        }))
+        .sort((a, b) => {
+          if (a.day !== b.day) {
+            return a.day - b.day;
+          }
+          const timeComparison = a.startTime.localeCompare(b.startTime);
+          if (timeComparison !== 0) {
+            return timeComparison;
+          }
+          return (a.id ?? 0) - (b.id ?? 0);
+        });
+
+      return JSON.stringify(flattened);
+    },
+    []
+  );
+
+  const serializedCurrentItineraries = useMemo(
+    () => serializeItineraries(itineraries),
+    [itineraries, serializeItineraries]
+  );
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+
+    if (initialItinerariesSnapshotRef.current === null) {
+      initialItinerariesSnapshotRef.current = serializedCurrentItineraries;
+      setHasUnsavedChanges(false);
+      return;
+    }
+
+    setHasUnsavedChanges(
+      initialItinerariesSnapshotRef.current !== serializedCurrentItineraries
+    );
+  }, [isLoading, serializedCurrentItineraries]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (event) => {
+      if (allowNavigationRef.current || !hasUnsavedChanges || isSaving) {
+        return;
+      }
+
+      event.preventDefault();
+
+      Alert.alert(
+        '저장되지 않은 변경 사항',
+        '변경 내용을 저장하지 않고 나가시겠어요?',
+        [
+          { text: '취소', style: 'cancel' },
+          {
+            text: '나가기',
+            style: 'destructive',
+            onPress: () => {
+              allowNavigationRef.current = true;
+              navigation.dispatch(event.data.action);
+            },
+          },
+        ]
+      );
+    });
+
+    return unsubscribe;
+  }, [navigation, hasUnsavedChanges, isSaving]);
 
   /**
    * 선택된 일정 항목의 편집 화면으로 이동합니다.
@@ -206,6 +294,10 @@ const EditTemplateItinerariesScreen: React.FC = () => {
       const result = await setTemplateItineraries(+id, newItineraries);
 
       if (result?.success) {
+        initialItinerariesSnapshotRef.current =
+          serializeItineraries(itineraries);
+        setHasUnsavedChanges(false);
+        allowNavigationRef.current = true;
         router.back();
       } else {
         // 에러가 발생한 경우 - 이전 화면으로 돌아가지 않음
@@ -353,7 +445,10 @@ const EditTemplateItinerariesScreen: React.FC = () => {
         />
 
         <View style={[styles.addButtonContainer]}>
-          <TouchableOpacity style={styles.addItineraryButton} onPress={handleAdd}>
+          <TouchableOpacity
+            style={styles.addItineraryButton}
+            onPress={handleAdd}
+          >
             <Ionicons name='add-circle' size={24} color='#fff' />
             <Text style={styles.addItineraryButtonText}>일정 추가</Text>
           </TouchableOpacity>

--- a/app/(app)/guide/template/[id]/edit-itineraries.tsx
+++ b/app/(app)/guide/template/[id]/edit-itineraries.tsx
@@ -172,7 +172,7 @@ const EditTemplateItinerariesScreen: React.FC = () => {
   const handleAdd = () => {
     const newItinerary: TemplateItinerary = {
       day: day, // 현재 선택된 day에 추가하도록 수정
-      title: '',
+      location: '서울시청',
       content: '',
       startTime: '00:00',
       latitude: 37.5665,

--- a/app/(app)/guide/template/[id]/edit-itinerary.tsx
+++ b/app/(app)/guide/template/[id]/edit-itinerary.tsx
@@ -34,7 +34,7 @@ const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
 
 type ItineraryParamProps = {
   day: string;
-  title: string;
+  location: string;
   content: string;
   startTime: string;
   latitude: string;
@@ -47,7 +47,7 @@ const EditTemplateItineraryScreen: React.FC = () => {
   const params = useLocalSearchParams<ItineraryParamProps>();
   const { updateItinerary, setDay } = useTemplateDetails();
 
-  const [title, setTitle] = useState(params.title || '');
+  const [location, setLocation] = useState(params.location || '');
   const [localDay, setLocalDay] = useState(params.day || '');
   const [content, setContent] = useState(params.content || '');
   const [startTime, setStartTime] = useState(params.startTime || '09:00');
@@ -123,7 +123,7 @@ const EditTemplateItineraryScreen: React.FC = () => {
   };
 
   const handleEditSchedule = () => {
-    if (!localDay || !title || !startTime || !latitude || !longitude) {
+    if (!localDay || !location || !startTime || !latitude || !longitude) {
       Toast.show({
         type: 'error',
         text1: '모든 필드를 채워주세요.',
@@ -135,7 +135,7 @@ const EditTemplateItineraryScreen: React.FC = () => {
     const newSchedule: TemplateItinerary = {
       id: +params.itineraryId,
       day: +localDay,
-      title: title,
+      location: location,
       content: content,
       startTime: startTime,
       latitude: +latitude,
@@ -152,10 +152,10 @@ const EditTemplateItineraryScreen: React.FC = () => {
     setIsMapExpanded(expand);
   };
 
-  const handlePlaceSelect = (place: { latitude: number; longitude: number }) => {
+  const handlePlaceSelect = (place: { name: string, latitude: number; longitude: number }) => {
     setLatitude(place.latitude.toString());
     setLongitude(place.longitude.toString());
-    // Optional: close map after selection
+    setLocation(place.name);
     toggleMapExpansion(false);
   };
 
@@ -220,13 +220,15 @@ const EditTemplateItineraryScreen: React.FC = () => {
           {!isMapExpanded && (
             <ScrollView contentContainerStyle={styles.scrollViewContent}>
               <View style={styles.formSection}>
-                <Text style={styles.label}>장소명 또는 일정명</Text>
+                <Text style={styles.label}>장소명</Text>
                 <TextInput
-                  value={title}
-                  onChangeText={setTitle}
-                  placeholder='장소명 또는 일정명을 입력하세요'
+                  value={location}
+                  onChangeText={setLocation}
+                  placeholder='장소명'
                   placeholderTextColor={'#9A9A9A'}
-                  style={styles.input}
+                  style={[styles.input, { opacity: 0.5 }]}
+                  editable={false}
+                  selectTextOnFocus={false}
                 />
               </View>
 

--- a/app/(app)/guide/template/[id]/edit-itinerary.tsx
+++ b/app/(app)/guide/template/[id]/edit-itinerary.tsx
@@ -18,7 +18,7 @@ import {
   TextInput,
   TouchableOpacity,
   UIManager,
-  View
+  View,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 
@@ -47,8 +47,13 @@ const EditTemplateItineraryScreen: React.FC = () => {
   const params = useLocalSearchParams<ItineraryParamProps>();
   const { updateItinerary, setDay } = useTemplateDetails();
 
+  const parseDay = (dayParam?: string) => {
+    const parsed = parseInt(dayParam ?? '', 10);
+    return isNaN(parsed) || parsed < 1 ? 1 : parsed;
+  };
+
   const [location, setLocation] = useState(params.location || '');
-  const [localDay, setLocalDay] = useState(params.day || '');
+  const [dayValue, setDayValue] = useState<number>(parseDay(params.day));
   const [content, setContent] = useState(params.content || '');
   const [startTime, setStartTime] = useState(params.startTime || '09:00');
   const [latitude, setLatitude] = useState(params.latitude || '37.5665');
@@ -62,7 +67,7 @@ const EditTemplateItineraryScreen: React.FC = () => {
       longitude: parseFloat(longitude) || 126.978,
       zoom: 16,
     }),
-    [latitude, longitude, isMapExpanded]
+    [latitude, longitude]
   );
 
   const clusterMarkers = useMemo(
@@ -123,7 +128,7 @@ const EditTemplateItineraryScreen: React.FC = () => {
   };
 
   const handleEditSchedule = () => {
-    if (!localDay || !location || !startTime || !latitude || !longitude) {
+    if (!dayValue || !location || !startTime || !latitude || !longitude) {
       Toast.show({
         type: 'error',
         text1: '모든 필드를 채워주세요.',
@@ -134,7 +139,7 @@ const EditTemplateItineraryScreen: React.FC = () => {
     }
     const newSchedule: TemplateItinerary = {
       id: +params.itineraryId,
-      day: +localDay,
+      day: dayValue,
       location: location,
       content: content,
       startTime: startTime,
@@ -152,11 +157,23 @@ const EditTemplateItineraryScreen: React.FC = () => {
     setIsMapExpanded(expand);
   };
 
-  const handlePlaceSelect = (place: { name: string, latitude: number; longitude: number }) => {
+  const handlePlaceSelect = (place: {
+    name: string;
+    latitude: number;
+    longitude: number;
+  }) => {
     setLatitude(place.latitude.toString());
     setLongitude(place.longitude.toString());
     setLocation(place.name);
     toggleMapExpansion(false);
+  };
+
+  const handleIncreaseDay = () => {
+    setDayValue((prev) => prev + 1);
+  };
+
+  const handleDecreaseDay = () => {
+    setDayValue((prev) => Math.max(prev - 1, 1));
   };
 
   return (
@@ -182,7 +199,10 @@ const EditTemplateItineraryScreen: React.FC = () => {
           )}
 
           <View
-            style={[styles.mapContainer, isMapExpanded && styles.mapContainerExpanded]}
+            style={[
+              styles.mapContainer,
+              isMapExpanded && styles.mapContainerExpanded,
+            ]}
           >
             <InteractiveMapView
               cameraPosition={cameraPosition}
@@ -197,7 +217,10 @@ const EditTemplateItineraryScreen: React.FC = () => {
             {/* This overlay captures the press to expand, only when not expanded */}
             {!isMapExpanded && (
               <TouchableOpacity
-                style={[StyleSheet.absoluteFill, { backgroundColor: 'transparent' }]}
+                style={[
+                  StyleSheet.absoluteFill,
+                  { backgroundColor: 'transparent' },
+                ]}
                 onPress={() => toggleMapExpansion(true)}
               />
             )}
@@ -205,13 +228,13 @@ const EditTemplateItineraryScreen: React.FC = () => {
             {isMapExpanded && (
               <View
                 style={styles.expandedMapOverlayContainer}
-                pointerEvents="box-none"
+                pointerEvents='box-none'
               >
                 <TouchableOpacity
                   onPress={() => toggleMapExpansion(false)}
                   style={styles.closeButton}
                 >
-                  <Ionicons name="close" size={28} color="#fff" />
+                  <Ionicons name='close' size={28} color='#fff' />
                 </TouchableOpacity>
               </View>
             )}
@@ -234,15 +257,22 @@ const EditTemplateItineraryScreen: React.FC = () => {
 
               {/* Other form sections... */}
               <View style={styles.formSection}>
-                <Text style={styles.label}>Day</Text>
-                <TextInput
-                  value={localDay}
-                  onChangeText={setLocalDay}
-                  placeholder='Day'
-                  placeholderTextColor={'#9A9A9A'}
-                  style={styles.input}
-                  keyboardType='number-pad'
-                />
+                <Text style={styles.label}>일차</Text>
+                <View style={styles.counterContainer}>
+                  <TouchableOpacity
+                    style={styles.counterButton}
+                    onPress={handleDecreaseDay}
+                  >
+                    <Ionicons name='remove' size={20} color='#613EEA' />
+                  </TouchableOpacity>
+                  <Text style={styles.counterValue}>{dayValue}</Text>
+                  <TouchableOpacity
+                    style={styles.counterButton}
+                    onPress={handleIncreaseDay}
+                  >
+                    <Ionicons name='add' size={20} color='#613EEA' />
+                  </TouchableOpacity>
+                </View>
               </View>
 
               <View style={styles.formSection}>
@@ -265,7 +295,9 @@ const EditTemplateItineraryScreen: React.FC = () => {
                   style={styles.input}
                 >
                   <View style={styles.timeInputContainer}>
-                    <Text style={styles.timeText}>{startTime.substring(0, 5)}</Text>
+                    <Text style={styles.timeText}>
+                      {startTime.substring(0, 5)}
+                    </Text>
                     <Ionicons name='time-outline' size={20} color='#8130FF' />
                   </View>
                 </TouchableOpacity>
@@ -385,6 +417,32 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  counterContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFF',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  counterButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFF',
+    borderWidth: 1,
+    borderColor: '#E5E5E5',
+  },
+  counterValue: {
+    minWidth: 48,
+    textAlign: 'center',
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#000',
+    marginHorizontal: 16,
   },
 });
 

--- a/app/(app)/guide/template/[id]/edit-itinerary.tsx
+++ b/app/(app)/guide/template/[id]/edit-itinerary.tsx
@@ -53,7 +53,7 @@ const EditTemplateItineraryScreen: React.FC = () => {
   };
 
   const [location, setLocation] = useState(params.location || '');
-  const [dayValue, setDayValue] = useState<number>(parseDay(params.day));
+  const dayValue = useMemo(() => parseDay(params.day), [params.day]);
   const [content, setContent] = useState(params.content || '');
   const [startTime, setStartTime] = useState(params.startTime || '09:00');
   const [latitude, setLatitude] = useState(params.latitude || '37.5665');
@@ -168,14 +168,6 @@ const EditTemplateItineraryScreen: React.FC = () => {
     toggleMapExpansion(false);
   };
 
-  const handleIncreaseDay = () => {
-    setDayValue((prev) => prev + 1);
-  };
-
-  const handleDecreaseDay = () => {
-    setDayValue((prev) => Math.max(prev - 1, 1));
-  };
-
   return (
     <CustomSafeAreaView>
       <CustomKeyboardAvoidingView>
@@ -242,36 +234,33 @@ const EditTemplateItineraryScreen: React.FC = () => {
 
           {!isMapExpanded && (
             <ScrollView contentContainerStyle={styles.scrollViewContent}>
-              <View style={styles.formSection}>
-                <Text style={styles.label}>장소명</Text>
-                <TextInput
-                  value={location}
-                  onChangeText={setLocation}
-                  placeholder='장소명'
-                  placeholderTextColor={'#9A9A9A'}
-                  style={[styles.input, { opacity: 0.5 }]}
-                  editable={false}
-                  selectTextOnFocus={false}
-                />
-              </View>
-
-              {/* Other form sections... */}
-              <View style={styles.formSection}>
-                <Text style={styles.label}>일차</Text>
-                <View style={styles.counterContainer}>
-                  <TouchableOpacity
-                    style={styles.counterButton}
-                    onPress={handleDecreaseDay}
+              <View style={styles.infoRow}>
+                <View style={styles.dayInfoWrapper}>
+                  <View style={styles.dayInfoContainer}>
+                    <Ionicons
+                      name='calendar-outline'
+                      size={18}
+                      color='#4C2EE7'
+                      style={styles.dayInfoIcon}
+                    />
+                    <Text style={styles.dayInfoText}>{dayValue}일차</Text>
+                  </View>
+                </View>
+                <View style={styles.locationInfoContainer}>
+                  <Ionicons
+                    name='location-outline'
+                    size={18}
+                    color='#4C2EE7'
+                    style={styles.locationInfoIcon}
+                  />
+                  <Text style={styles.locationInfoLabel}>장소</Text>
+                  <Text
+                    style={styles.locationInfoText}
+                    numberOfLines={1}
+                    ellipsizeMode='tail'
                   >
-                    <Ionicons name='remove' size={20} color='#613EEA' />
-                  </TouchableOpacity>
-                  <Text style={styles.counterValue}>{dayValue}</Text>
-                  <TouchableOpacity
-                    style={styles.counterButton}
-                    onPress={handleIncreaseDay}
-                  >
-                    <Ionicons name='add' size={20} color='#613EEA' />
-                  </TouchableOpacity>
+                    {location || '장소를 선택하세요'}
+                  </Text>
                 </View>
               </View>
 
@@ -368,12 +357,12 @@ const styles = StyleSheet.create({
     width: screenWidth,
     height: screenHeight,
     marginBottom: 0,
-    zIndex: 10, // Make sure map is on top
+    zIndex: 10, // Ensure map is on top
   },
   expandedMapOverlayContainer: {
     flex: 1,
     justifyContent: 'space-between',
-    paddingTop: 40, // Safe area for status bar
+    paddingTop: 40,
   },
   closeButton: {
     position: 'absolute',
@@ -385,7 +374,7 @@ const styles = StyleSheet.create({
     height: 40,
     justifyContent: 'center',
     alignItems: 'center',
-    zIndex: 20, // Ensure close button is on top of everything
+    zIndex: 20,
   },
   formSection: {
     marginBottom: 20,
@@ -418,31 +407,63 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
   },
-  counterContainer: {
+  infoRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#FFF',
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+    justifyContent: 'space-between',
+    marginBottom: 24,
+    gap: 16,
   },
-  counterButton: {
-    width: 34,
-    height: 34,
-    borderRadius: 17,
+  dayInfoWrapper: {
+    flexShrink: 0,
+  },
+  dayInfoContainer: {
+    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#FFF',
+    alignSelf: 'flex-start',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 14,
+    backgroundColor: 'transparent',
     borderWidth: 1,
-    borderColor: '#E5E5E5',
+    borderColor: '#DCD1FF',
   },
-  counterValue: {
-    minWidth: 48,
-    textAlign: 'center',
-    fontSize: 16,
+  dayInfoIcon: {
+    marginRight: 8,
+  },
+  dayInfoText: {
+    fontSize: 14,
     fontWeight: '600',
-    color: '#000',
-    marginHorizontal: 16,
+    color: '#4C2EE7',
+    letterSpacing: 0.2,
+  },
+  locationInfoContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 14,
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: '#DCD1FF',
+  },
+  locationInfoIcon: {
+    marginRight: 8,
+  },
+  locationInfoLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#6B5AF5',
+    marginRight: 8,
+    letterSpacing: 0.2,
+  },
+  locationInfoText: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#1E1E1E',
+    letterSpacing: 0.2,
   },
 });
 

--- a/app/(app)/guide/template/[id]/index.tsx
+++ b/app/(app)/guide/template/[id]/index.tsx
@@ -502,7 +502,7 @@ const ProductDetailScreen: React.FC = () => {
                   </Text>
                 </View>
                 <View style={styles.itineraryContent}>
-                  <Text style={styles.itineraryTitle}>{item.title}</Text>
+                  <Text style={styles.itineraryTitle}>{item.location}</Text>
                   {item.content ? (
                     <Text style={styles.itineraryDesc}>{item.content}</Text>
                   ) : null}

--- a/app/(app)/guide/template/[id]/index.tsx
+++ b/app/(app)/guide/template/[id]/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/services/templates';
 import { Ionicons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
+import * as ImagePicker from 'expo-image-picker';
 import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -18,6 +19,8 @@ import {
   Alert,
   Dimensions,
   Modal,
+  Platform,
+  Pressable,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -232,7 +235,7 @@ const ProductDetailScreen: React.FC = () => {
     );
   };
 
-  const handleSetImages = async (uris: string[]) => {
+  const handleSetImages = useCallback(async (uris: string[]) => {
     try {
       const newImageUrls = await setTemplateImageUrls(_id, uris);
       if (newImageUrls) {
@@ -242,7 +245,31 @@ const ProductDetailScreen: React.FC = () => {
     } catch (error) {
       console.error(error);
     }
-  };
+  }, [_id, setImageUrls]);
+
+  const handleOpenCoverImageEditor = useCallback(async () => {
+    if (Platform.OS !== 'web') {
+      const { status } =
+        await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (status !== 'granted') {
+        alert('Sorry, we need camera roll permissions to make this work!');
+        return;
+      }
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsMultipleSelection: true,
+      quality: 1,
+    });
+
+    if (!result.canceled) {
+      const uris = result.assets.map((asset) => asset.uri);
+      await handleSetImages(uris);
+    } else {
+      await handleSetImages([]);
+    }
+  }, [handleSetImages]);
 
   if (isInitialLoading) {
     return <FullScreenLoader />;
@@ -271,11 +298,16 @@ const ProductDetailScreen: React.FC = () => {
                 bounces={false}
               >
                 {imageUrls.map((imageUrl, index) => (
-                  <Image
+                  <Pressable
                     key={index}
-                    source={{ uri: imageUrl }}
-                    style={styles.coverImage}
-                  />
+                    style={styles.coverImageWrapper}
+                    onPress={handleOpenCoverImageEditor}
+                  >
+                    <Image
+                      source={{ uri: imageUrl }}
+                      style={styles.coverImage}
+                    />
+                  </Pressable>
                 ))}
               </ScrollView>
 
@@ -298,10 +330,13 @@ const ProductDetailScreen: React.FC = () => {
               )}
             </>
           ) : (
-            <View style={styles.placeholderContainer}>
+            <Pressable
+              style={styles.placeholderContainer}
+              onPress={handleOpenCoverImageEditor}
+            >
               <Ionicons name='image-outline' size={48} color='#9CA3AF' />
               <Text style={styles.placeholderText}>대표 이미지 없음</Text>
-            </View>
+            </Pressable>
           )}
 
           {/* 페이지 인디케이터 */}
@@ -646,6 +681,10 @@ const styles = StyleSheet.create({
     width: Dimensions.get('window').width,
     height: '100%',
     resizeMode: 'cover',
+  },
+  coverImageWrapper: {
+    width: Dimensions.get('window').width,
+    height: '100%',
   },
   coverPlaceholder: {
     position: 'absolute',

--- a/app/(app)/guide/template/[id]/index.tsx
+++ b/app/(app)/guide/template/[id]/index.tsx
@@ -44,10 +44,6 @@ const ProductDetailScreen: React.FC = () => {
     regionIds,
     tagIds,
     imageUrls,
-    isEditingContent,
-    isEditingTitle,
-    setIsEditingContent,
-    setIsEditingTitle,
     setTitle,
     setContent,
     setImageUrls,
@@ -70,6 +66,10 @@ const ProductDetailScreen: React.FC = () => {
   const [scrollViewRef, setScrollViewRef] = useState<ScrollView | null>(null);
   const screenWidth = Dimensions.get('window').width;
 
+  // Local title and description
+  const [localTitle, setLocalTitle] = useState<string>(title);
+  const [localContent, setLocalContent] = useState<string>(content);
+
   // 초기 로딩과 새로고침을 구분하기 위한 변수
   // 데이터가 전혀 없을 때의 로딩만 전체 화면 로딩으로 간주
   const isInitialLoading = isLoading && Object.keys(itineraries).length === 0;
@@ -85,6 +85,11 @@ const ProductDetailScreen: React.FC = () => {
   const [selectedDay, setSelectedDay] = useState(
     availableDays.length > 0 ? availableDays[0] : 1
   );
+
+  useEffect(() => {
+    setLocalTitle(title);
+    setLocalContent(content);
+  }, [title, content]);
 
   useEffect(() => {
     if (availableDays.length > 0 && !availableDays.includes(selectedDay)) {
@@ -159,34 +164,39 @@ const ProductDetailScreen: React.FC = () => {
    * 템플릿 제목의 편집 모드를 토글하고, 편집 완료 시 서버에 변경사항을 저장합니다.
    */
   const handleEditTitle = async () => {
-    if (isEditingTitle) {
-      setIsSavingTitle(true);
-      try {
-        await setTemplateTitle(_id, title);
-      } catch (error) {
-        console.error(error);
-      } finally {
-        setIsSavingTitle(false);
-      }
+    if (localTitle === title) {
+      return;
     }
-    setIsEditingTitle((prev) => !prev);
+
+    setIsSavingTitle(true);
+    try {
+      await setTemplateTitle(_id, localTitle);
+      setTitle(localTitle);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      console.log(title, localTitle);
+      setIsSavingTitle(false);
+    }
   };
 
   /**
    * 템플릿 소개 내용의 편집 모드를 토글하고, 편집 완료 시 서버에 변경사항을 저장합니다.
    */
   const handleEditContent = async () => {
-    if (isEditingContent) {
-      setIsSavingContent(true);
-      try {
-        await setTemplateContent(_id, content);
-      } catch (error) {
-        console.error(error);
-      } finally {
-        setIsSavingContent(false);
-      }
+    if (localContent === content) {
+      return;
     }
-    setIsEditingContent((prev) => !prev);
+
+    setIsSavingContent(true);
+    try {
+      await setTemplateContent(_id, localContent);
+      setContent(localContent);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsSavingContent(false);
+    }
   };
 
   // Location and Tags will navigate to separate edit screens; no local edit state needed
@@ -312,29 +322,23 @@ const ProductDetailScreen: React.FC = () => {
 
         <View style={styles.section}>
           <View style={styles.rowBetween}>
-            {isEditingTitle ? (
-              <TextInput
-                value={title}
-                onChangeText={setTitle}
-                style={styles.titleInput}
-                placeholder='제목을 입력하세요'
-                editable={!isSavingTitle}
-              />
-            ) : (
-              <Text style={[styles.title, { flex: 1, marginBottom: 0 }]}>
-                {title}
-              </Text>
-            )}
+            <TextInput
+              value={localTitle}
+              onChangeText={setLocalTitle}
+              style={styles.titleInput}
+              placeholder='제목을 입력하세요'
+              editable={!isSavingTitle}
+            />
             <TouchableOpacity
-              style={styles.editButton}
+              style={[styles.editButton, (isSavingTitle || localTitle === title) && { opacity: 0.5 }]}
               onPress={handleEditTitle}
-              disabled={isSavingTitle}
+              disabled={isSavingTitle || localTitle === title}
             >
               {isSavingTitle ? (
                 <ActivityIndicator size='small' />
               ) : (
                 <Text style={styles.editButtonText}>
-                  {isEditingTitle ? '저장' : '편집'}
+                  저장
                 </Text>
               )}
             </TouchableOpacity>
@@ -380,32 +384,28 @@ const ProductDetailScreen: React.FC = () => {
               여행 소개
             </Text>
             <TouchableOpacity
-              style={styles.editButton}
+              style={[styles.editButton, (isSavingContent || localContent === content) && { opacity: 0.5 }]}
               onPress={handleEditContent}
-              disabled={isSavingContent}
+              disabled={(isSavingContent || localContent === content)}
             >
               {isSavingContent ? (
                 <ActivityIndicator size='small' />
               ) : (
                 <Text style={styles.editButtonText}>
-                  {isEditingContent ? '완료' : '편집'}
+                  저장
                 </Text>
               )}
             </TouchableOpacity>
           </View>
-          {isEditingContent ? (
-            <TextInput
-              value={content}
-              onChangeText={setContent}
-              style={styles.multilineInput}
-              multiline
-              textAlignVertical='top'
-              placeholder='여행 소개를 입력하세요'
-              editable={!isSavingContent}
-            />
-          ) : (
-            <Text style={styles.description}>{content}</Text>
-          )}
+          <TextInput
+            value={localContent}
+            onChangeText={setLocalContent}
+            style={styles.multilineInput}
+            multiline
+            textAlignVertical='top'
+            placeholder='여행 소개를 입력하세요'
+            editable={!isSavingContent}
+          />
         </View>
 
         <View style={styles.divider} />
@@ -537,7 +537,7 @@ const ProductDetailScreen: React.FC = () => {
         {/* 삭제 버튼 */}
         <View style={styles.rightIcons}>
           <TouchableOpacity
-            style={styles.deleteButton}
+            style={[styles.deleteButton, isDeleting && { opacity: 0.5 }]}
             onPress={handleDeleteTemplate}
             disabled={isDeleting}
           >

--- a/app/(app)/guide/template/[id]/index.tsx
+++ b/app/(app)/guide/template/[id]/index.tsx
@@ -80,14 +80,15 @@ const ProductDetailScreen: React.FC = () => {
 
   const availableDays = useMemo(
     () =>
-      Object.keys(itineraries)
-        .map(Number)
+      Object.entries(itineraries)
+        .filter(([, items]) => Array.isArray(items) && items.length > 0)
+        .map(([day]) => Number(day))
         .sort((a, b) => a - b),
     [itineraries]
   );
 
-  const [selectedDay, setSelectedDay] = useState(
-    availableDays.length > 0 ? availableDays[0] : 1
+  const [selectedDay, setSelectedDay] = useState<number | null>(
+    availableDays.length > 0 ? availableDays[0] : null
   );
 
   useEffect(() => {
@@ -96,7 +97,12 @@ const ProductDetailScreen: React.FC = () => {
   }, [title, content]);
 
   useEffect(() => {
-    if (availableDays.length > 0 && !availableDays.includes(selectedDay)) {
+    if (availableDays.length === 0) {
+      setSelectedDay(null);
+      return;
+    }
+
+    if (selectedDay === null || !availableDays.includes(selectedDay)) {
       setSelectedDay(availableDays[0]);
     }
   }, [availableDays, selectedDay]);
@@ -527,51 +533,63 @@ const ProductDetailScreen: React.FC = () => {
           </View>
         </View>
 
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.daySelection}
-        >
-          {availableDays.map((dayNumber) => (
-            <TouchableOpacity
-              key={dayNumber}
-              style={[
-                styles.dayButton,
-                selectedDay === dayNumber && styles.dayButtonActive,
-              ]}
-              onPress={() => setSelectedDay(dayNumber)}
+        {availableDays.length === 0 ? (
+          <View style={styles.emptyItineraryContainer}>
+            <Ionicons name='calendar-clear-outline' size={40} color='#9CA3AF' />
+            <Text style={styles.emptyItineraryTitle}>등록된 일정이 없어요</Text>
+            <Text style={styles.emptyItinerarySubtitle}>
+              편집 버튼을 눌러 일정을 추가해보세요.
+            </Text>
+          </View>
+        ) : (
+          <>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.daySelection}
             >
-              <Text
-                style={[
-                  styles.dayButtonText,
-                  selectedDay === dayNumber && styles.dayButtonTextActive,
-                ]}
-              >
-                {dayNumber}일차
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
-
-        <View style={[styles.section, { paddingTop: 0 }]}>
-          {(itineraries[selectedDay] || [])
-            .sort((a, b) => a.startTime.localeCompare(b.startTime))
-            .map((item) => (
-              <View key={item.id} style={styles.itineraryItem}>
-                <View style={styles.itineraryTime}>
-                  <Text style={styles.itineraryTimeText}>
-                    {item.startTime.substring(0, 5)}
+              {availableDays.map((dayNumber) => (
+                <TouchableOpacity
+                  key={dayNumber}
+                  style={[
+                    styles.dayButton,
+                    selectedDay === dayNumber && styles.dayButtonActive,
+                  ]}
+                  onPress={() => setSelectedDay(dayNumber)}
+                >
+                  <Text
+                    style={[
+                      styles.dayButtonText,
+                      selectedDay === dayNumber && styles.dayButtonTextActive,
+                    ]}
+                  >
+                    {dayNumber}일차
                   </Text>
-                </View>
-                <View style={styles.itineraryContent}>
-                  <Text style={styles.itineraryTitle}>{item.location}</Text>
-                  {item.content ? (
-                    <Text style={styles.itineraryDesc}>{item.content}</Text>
-                  ) : null}
-                </View>
-              </View>
-            ))}
-        </View>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+
+            <View style={[styles.section, { paddingTop: 0 }]}>
+              {(selectedDay !== null ? itineraries[selectedDay] || [] : [])
+                .sort((a, b) => a.startTime.localeCompare(b.startTime))
+                .map((item) => (
+                  <View key={item.id} style={styles.itineraryItem}>
+                    <View style={styles.itineraryTime}>
+                      <Text style={styles.itineraryTimeText}>
+                        {item.startTime.substring(0, 5)}
+                      </Text>
+                    </View>
+                    <View style={styles.itineraryContent}>
+                      <Text style={styles.itineraryTitle}>{item.location}</Text>
+                      {item.content ? (
+                        <Text style={styles.itineraryDesc}>{item.content}</Text>
+                      ) : null}
+                    </View>
+                  </View>
+                ))}
+            </View>
+          </>
+        )}
 
         <View style={{ height: 40 }} />
       </ScrollView>
@@ -1077,6 +1095,23 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#444',
     lineHeight: 20,
+  },
+  emptyItineraryContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 48,
+    paddingHorizontal: 24,
+    gap: 8,
+  },
+  emptyItineraryTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#4B5563',
+  },
+  emptyItinerarySubtitle: {
+    fontSize: 14,
+    color: '#9CA3AF',
+    textAlign: 'center',
   },
   bottomActionContainer: {
     position: 'absolute',

--- a/app/(app)/guide/template/[id]/index.tsx
+++ b/app/(app)/guide/template/[id]/index.tsx
@@ -30,6 +30,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Toast from 'react-native-toast-message';
 
 /**
  * 특정 여행 템플릿의 모든 상세 정보를 보여주는 화면입니다.
@@ -163,6 +164,21 @@ const ProductDetailScreen: React.FC = () => {
 
   const _id: number = +id;
 
+  const showErrorToast = (error: unknown) => {
+    const message =
+      error instanceof Error && typeof error.message === 'string'
+        ? error.message
+        : '오류가 발생했습니다.';
+
+    Toast.show({
+      type: 'error',
+      text1: '요청 실패',
+      text2: message,
+      position: 'bottom',
+      bottomOffset: 100,
+    });
+  };
+
   /**
    * 템플릿 제목의 편집 모드를 토글하고, 편집 완료 시 서버에 변경사항을 저장합니다.
    */
@@ -177,6 +193,7 @@ const ProductDetailScreen: React.FC = () => {
       setTitle(localTitle);
     } catch (error) {
       console.error(error);
+      showErrorToast(error);
     } finally {
       console.log(title, localTitle);
       setIsSavingTitle(false);
@@ -197,6 +214,7 @@ const ProductDetailScreen: React.FC = () => {
       setContent(localContent);
     } catch (error) {
       console.error(error);
+      showErrorToast(error);
     } finally {
       setIsSavingContent(false);
     }
@@ -226,6 +244,7 @@ const ProductDetailScreen: React.FC = () => {
               router.back();
             } catch (error) {
               console.error(error);
+              showErrorToast(error);
             } finally {
               setIsDeleting(false);
             }
@@ -245,6 +264,7 @@ const ProductDetailScreen: React.FC = () => {
         }
       } catch (error) {
         console.error(error);
+        showErrorToast(error);
       }
     },
     [_id, setImageUrls]

--- a/app/(app)/guide/template/[id]/index.tsx
+++ b/app/(app)/guide/template/[id]/index.tsx
@@ -235,17 +235,20 @@ const ProductDetailScreen: React.FC = () => {
     );
   };
 
-  const handleSetImages = useCallback(async (uris: string[]) => {
-    try {
-      const newImageUrls = await setTemplateImageUrls(_id, uris);
-      if (newImageUrls) {
-        setImageUrls(newImageUrls);
-        console.log(newImageUrls);
+  const handleSetImages = useCallback(
+    async (uris: string[]) => {
+      try {
+        const newImageUrls = await setTemplateImageUrls(_id, uris);
+        if (newImageUrls) {
+          setImageUrls(newImageUrls);
+          console.log(newImageUrls);
+        }
+      } catch (error) {
+        console.error(error);
       }
-    } catch (error) {
-      console.error(error);
-    }
-  }, [_id, setImageUrls]);
+    },
+    [_id, setImageUrls]
+  );
 
   const handleOpenCoverImageEditor = useCallback(async () => {
     if (Platform.OS !== 'web') {
@@ -365,16 +368,17 @@ const ProductDetailScreen: React.FC = () => {
               editable={!isSavingTitle}
             />
             <TouchableOpacity
-              style={[styles.editButton, (isSavingTitle || localTitle === title) && { opacity: 0.5 }]}
+              style={[
+                styles.editButton,
+                (isSavingTitle || localTitle === title) && { opacity: 0.5 },
+              ]}
               onPress={handleEditTitle}
               disabled={isSavingTitle || localTitle === title}
             >
               {isSavingTitle ? (
                 <ActivityIndicator size='small' />
               ) : (
-                <Text style={styles.editButtonText}>
-                  저장
-                </Text>
+                <Text style={styles.editButtonText}>저장</Text>
               )}
             </TouchableOpacity>
           </View>
@@ -419,16 +423,19 @@ const ProductDetailScreen: React.FC = () => {
               여행 소개
             </Text>
             <TouchableOpacity
-              style={[styles.editButton, (isSavingContent || localContent === content) && { opacity: 0.5 }]}
+              style={[
+                styles.editButton,
+                (isSavingContent || localContent === content) && {
+                  opacity: 0.5,
+                },
+              ]}
               onPress={handleEditContent}
-              disabled={(isSavingContent || localContent === content)}
+              disabled={isSavingContent || localContent === content}
             >
               {isSavingContent ? (
                 <ActivityIndicator size='small' />
               ) : (
-                <Text style={styles.editButtonText}>
-                  저장
-                </Text>
+                <Text style={styles.editButtonText}>저장</Text>
               )}
             </TouchableOpacity>
           </View>

--- a/app/(app)/guide/template/index.tsx
+++ b/app/(app)/guide/template/index.tsx
@@ -81,10 +81,9 @@ const MyTemplatesScreen: React.FC = () => {
     refetch();
   }, [refetch]);
 
-
   return (
     <CustomSafeAreaView>
-      <View className='bg-gray-50 pt-6 relative'>
+      <View className='flex-1 bg-gray-50 pt-6 relative'>
         {/* 초기 로딩 처리 */}
         {isLoading && templates.length === 0 ? (
           <FullScreenLoader />
@@ -107,6 +106,7 @@ const MyTemplatesScreen: React.FC = () => {
             <View className='bg-gray-50 rounded-2xl p-4'>
               <GuideTemplateList
                 templates={filteredTemplates}
+                userRole='GUIDE'
                 onEndReached={handleLoadMore}
                 onEndReachedThreshold={0.5}
                 ListFooterComponent={renderFooter}
@@ -123,7 +123,7 @@ const MyTemplatesScreen: React.FC = () => {
           className='absolute right-6 w-16 h-16 rounded-full bg-white items-center justify-center'
           style={{
             elevation: 8,
-            bottom: bottom + 60,
+            bottom: bottom,
           }}
           onPress={handleCreateTemplate}
         >

--- a/app/(app)/traveler/trip/[id]/session-room.tsx
+++ b/app/(app)/traveler/trip/[id]/session-room.tsx
@@ -4,7 +4,7 @@ import { SessionDetailsProvider } from '@/contexts/SessionDetailsProvider';
 import { useSessionDetails } from '@/hooks/sessions/useSessionDetails';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
   ScrollView,
@@ -21,7 +21,6 @@ import {
 const TravelerSessionRoomContent: React.FC = () => {
   const router = useRouter();
   const { id } = useLocalSearchParams<{ id: string }>(); // sessionId는 SessionDetailsProvider에서 관리
-  const [selectedDay, setSelectedDay] = useState(1);
 
   // 세션 상세 정보 가져오기
   const sessionDetails = useSessionDetails();
@@ -38,11 +37,31 @@ const TravelerSessionRoomContent: React.FC = () => {
   // 일정 관련 상태
   const availableDays = useMemo(
     () =>
-      Object.keys(itineraries)
-        .map(Number)
+      Object.entries(itineraries)
+        .filter(([, items]) => Array.isArray(items) && items.length > 0)
+        .map(([day]) => Number(day))
         .sort((a, b) => a - b),
     [itineraries]
   );
+
+  const [selectedDay, setSelectedDay] = useState<number | null>(
+    availableDays.length > 0 ? availableDays[0] : null
+  );
+
+  useEffect(() => {
+    if (availableDays.length === 0) {
+      setSelectedDay(null);
+      return;
+    }
+
+    setSelectedDay((prev) => {
+      if (prev !== null && availableDays.includes(prev)) {
+        return prev;
+      }
+
+      return availableDays[0];
+    });
+  }, [availableDays]);
 
   // 날짜 포맷팅
   const formatDate = (dateString: string) => {
@@ -190,25 +209,41 @@ const TravelerSessionRoomContent: React.FC = () => {
 
         {/* 일정 목록 */}
         <View style={styles.itinerarySection}>
-          {(itineraries[selectedDay] || [])
-            .sort((a, b) => a.startTime.localeCompare(b.startTime))
-            .map((item) => (
-              <View key={item.id} style={styles.itineraryItem}>
-                <View style={styles.itineraryTime}>
-                  <Text style={styles.itineraryTimeText}>
-                    {item.startTime.substring(0, 5)}
-                  </Text>
-                </View>
-                <View style={styles.itineraryContent}>
-                  <Text style={styles.itineraryTitle}>{item.title}</Text>
-                  {item.content ? (
-                    <Text style={styles.itineraryDescription}>
-                      {item.content}
+          {selectedDay === null ? (
+            <View style={styles.emptyItineraryContainer}>
+              <Ionicons
+                name='calendar-clear-outline'
+                size={40}
+                color='#9CA3AF'
+              />
+              <Text style={styles.emptyItineraryTitle}>
+                등록된 일정이 없어요
+              </Text>
+              <Text style={styles.emptyItinerarySubtitle}>
+                가이드가 일정을 추가하면 이곳에서 확인할 수 있어요.
+              </Text>
+            </View>
+          ) : (
+            (itineraries[selectedDay] || [])
+              .sort((a, b) => a.startTime.localeCompare(b.startTime))
+              .map((item) => (
+                <View key={item.id} style={styles.itineraryItem}>
+                  <View style={styles.itineraryTime}>
+                    <Text style={styles.itineraryTimeText}>
+                      {item.startTime.substring(0, 5)}
                     </Text>
-                  ) : null}
+                  </View>
+                  <View style={styles.itineraryContent}>
+                    <Text style={styles.itineraryTitle}>{item.location}</Text>
+                    {item.content ? (
+                      <Text style={styles.itineraryDescription}>
+                        {item.content}
+                      </Text>
+                    ) : null}
+                  </View>
                 </View>
-              </View>
-            ))}
+              ))
+          )}
         </View>
 
         <View style={{ height: 100 }} />
@@ -234,7 +269,6 @@ const TravelerSessionRoomScreen: React.FC = () => {
         <TravelerSessionRoomContent />
       </SessionDetailsProvider>
     </CustomSafeAreaView>
-    
   );
 };
 
@@ -441,6 +475,23 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#6B7280',
     lineHeight: 20,
+  },
+  emptyItineraryContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 48,
+    paddingHorizontal: 24,
+    gap: 8,
+  },
+  emptyItineraryTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#4B5563',
+  },
+  emptyItinerarySubtitle: {
+    fontSize: 14,
+    color: '#9CA3AF',
+    textAlign: 'center',
   },
   errorContainer: {
     flex: 1,

--- a/components/guide/template/GuideItineraryList.tsx
+++ b/components/guide/template/GuideItineraryList.tsx
@@ -67,7 +67,7 @@ const GuideItineraryList: React.FC<GuideItineraryListProps> = ({
             <View className='flex-row justify-between items-start'>
               <View className='flex-1 mr-3'>
                 <Text className='text-lg font-bold text-gray-900 mb-1 leading-5'>
-                  {item.title}
+                  {item.location}
                 </Text>
                 <Text className='text-sm text-gray-600 leading-5'>
                   {item.content}

--- a/components/map/InteractiveMapView.tsx
+++ b/components/map/InteractiveMapView.tsx
@@ -31,7 +31,7 @@ interface InteractiveMapViewProps {
   cameraPosition: Camera;
   clusterMarkers: ClusterMarkerProp[];
   options?: MapOverlayOptions;
-  onPlaceSelect?: (place: { latitude: number; longitude: number }) => void;
+  onPlaceSelect?: (place: { name: string, latitude: number; longitude: number }) => void;
   onMarkerClick?: (markerIdentifier: string) => void;
 }
 
@@ -84,7 +84,7 @@ export const InteractiveMapView = memo(
         try {
           const data = await fetchKakaoPlaceSearch(query);
           if (data && data.documents.length > 0) {
-            const { x, y } = data.documents[0];
+            const { place_name, x, y } = data.documents[0];
             const latitude = parseFloat(y);
             const longitude = parseFloat(x);
 
@@ -97,7 +97,7 @@ export const InteractiveMapView = memo(
 
             // Notify the parent component of the selected place
             if (onPlaceSelect) {
-              onPlaceSelect({ latitude, longitude });
+              onPlaceSelect({ name: place_name, latitude, longitude });
             }
           } else {
             Alert.alert('검색 결과 없음', `'${query}'에 대한 결과가 없습니다.`);

--- a/components/session/SessionDetailScreen.tsx
+++ b/components/session/SessionDetailScreen.tsx
@@ -136,21 +136,30 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
   // 일정 관련 상태
   const availableDays = useMemo(
     () =>
-      Object.keys(itineraries)
-        .map(Number)
+      Object.entries(itineraries)
+        .filter(([, items]) => Array.isArray(items) && items.length > 0)
+        .map(([day]) => Number(day))
         .sort((a, b) => a - b),
     [itineraries]
   );
 
-  const [selectedDay, setSelectedDay] = useState(
-    availableDays.length > 0 ? availableDays[0] : 1
+  const [selectedDay, setSelectedDay] = useState<number | null>(
+    availableDays.length > 0 ? availableDays[0] : null
   );
 
   useEffect(() => {
-    if (availableDays.length > 0 && !availableDays.includes(selectedDay)) {
-      setSelectedDay(availableDays[0]);
+    if (availableDays.length === 0) {
+      setSelectedDay(null);
+      return;
     }
-  }, [availableDays, selectedDay]);
+
+    setSelectedDay((prev) => {
+      if (prev !== null && availableDays.includes(prev)) {
+        return prev;
+      }
+      return availableDays[0];
+    });
+  }, [availableDays]);
 
   // 여행자용 참여 신청 처리
   const handleParticipation = useCallback(async () => {
@@ -716,12 +725,22 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
         <View style={styles.divider} />
 
         {/* 일정 섹션 */}
-        {availableDays.length > 0 && (
-          <>
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>일정</Text>
-            </View>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>일정</Text>
+        </View>
 
+        {availableDays.length === 0 ? (
+          <View style={styles.emptyItineraryContainer}>
+            <Ionicons name='calendar-clear-outline' size={40} color='#9CA3AF' />
+            <Text style={styles.emptyItineraryTitle}>등록된 일정이 없어요</Text>
+            <Text style={styles.emptyItinerarySubtitle}>
+              {userType === 'guide'
+                ? '편집 화면에서 일정을 추가해 보세요.'
+                : '가이드가 일정을 추가하면 이곳에서 확인할 수 있어요.'}
+            </Text>
+          </View>
+        ) : (
+          <>
             <ScrollView
               horizontal
               showsHorizontalScrollIndicator={false}
@@ -749,7 +768,7 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
             </ScrollView>
 
             <View style={[styles.section, { paddingTop: 0 }]}>
-              {(itineraries[selectedDay] || [])
+              {(selectedDay !== null ? itineraries[selectedDay] || [] : [])
                 .sort((a, b) => a.startTime.localeCompare(b.startTime))
                 .map((item) => (
                   <View key={item.id} style={styles.itineraryItem}>
@@ -1349,6 +1368,23 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#444',
     lineHeight: 20,
+  },
+  emptyItineraryContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 48,
+    paddingHorizontal: 24,
+    gap: 8,
+  },
+  emptyItineraryTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#4B5563',
+  },
+  emptyItinerarySubtitle: {
+    fontSize: 14,
+    color: '#9CA3AF',
+    textAlign: 'center',
   },
   photoGrid: {
     flexDirection: 'row',

--- a/components/session/SessionDetailScreen.tsx
+++ b/components/session/SessionDetailScreen.tsx
@@ -49,6 +49,7 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
 }) => {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const bottomActionPadding = Math.max(insets.bottom, 16);
   const segments = useSegments();
   const { id } = useLocalSearchParams<{ id: string }>();
 
@@ -774,7 +775,10 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
 
       {/* 하단 액션 버튼 */}
       <View
-        style={[styles.bottomActionContainer, { paddingBottom: insets.bottom }]}
+        style={[
+          styles.bottomActionContainer,
+          { paddingBottom: bottomActionPadding, bottom: -insets.bottom },
+        ]}
       >
         {userType === 'guide' ? (
           <>

--- a/components/session/SessionDetailScreen.tsx
+++ b/components/session/SessionDetailScreen.tsx
@@ -758,7 +758,7 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
                       </Text>
                     </View>
                     <View style={styles.itineraryContent}>
-                      <Text style={styles.itineraryTitle}>{item.title}</Text>
+                      <Text style={styles.itineraryTitle}>{item.location}</Text>
                       {item.content ? (
                         <Text style={styles.itineraryDesc}>{item.content}</Text>
                       ) : null}

--- a/contexts/TemplateDetailsProvider.tsx
+++ b/contexts/TemplateDetailsProvider.tsx
@@ -5,7 +5,8 @@ import React, {
   createContext,
   ReactNode,
   useCallback,
-  useState
+  useEffect,
+  useState,
 } from 'react';
 
 /**
@@ -104,6 +105,25 @@ const useTemplateDetailsLogic = (id: string) => {
       return groupItinerariesByDay(updatedList);
     });
   }, []);
+
+  useEffect(() => {
+    const availableDays = Object.keys(itineraries)
+      .map(Number)
+      .filter((value) => Number.isFinite(value))
+      .sort((a, b) => a - b);
+
+    if (availableDays.length === 0) {
+      if (day !== 1) {
+        setDay(1);
+      }
+      return;
+    }
+
+    if (!availableDays.includes(day)) {
+      const nextDay = availableDays.find((availableDay) => availableDay > day);
+      setDay(nextDay ?? availableDays[availableDays.length - 1]);
+    }
+  }, [itineraries, day]);
 
   return {
     isLoading,

--- a/contexts/TemplateDetailsProvider.tsx
+++ b/contexts/TemplateDetailsProvider.tsx
@@ -9,6 +9,31 @@ import React, {
   useState,
 } from 'react';
 
+const ensureDayKeys = (
+  source: Record<number, TemplateItinerary[]>,
+  baseDays: number[] = []
+): Record<number, TemplateItinerary[]> => {
+  const daySet = new Set<number>([
+    ...baseDays,
+    ...Object.keys(source)
+      .map(Number)
+      .filter((value) => Number.isFinite(value)),
+  ]);
+
+  if (daySet.size === 0) {
+    daySet.add(1);
+  }
+
+  const sortedDays = Array.from(daySet).sort((a, b) => a - b);
+  return sortedDays.reduce<Record<number, TemplateItinerary[]>>(
+    (acc, day) => {
+      acc[day] = source[day] ? [...source[day]] : [];
+      return acc;
+    },
+    {}
+  );
+};
+
 /**
  * 템플릿 상세 정보 관련 상태와 로직을 관리하는 내부 훅입니다.
  * 템플릿 ID를 기반으로 상세 정보와 일정 목록을 가져오고, 상태를 관리하는 다양한 함수를 제공합니다.
@@ -24,7 +49,9 @@ const useTemplateDetailsLogic = (id: string) => {
   const [imageUrls, setImageUrls] = useState<string[]>([]);
   const [itineraries, setItineraries] = useState<
     Record<number, TemplateItinerary[]>
-  >({});
+  >({
+    1: [],
+  });
   const [isEditingTitle, setIsEditingTitle] = useState<boolean>(false);
   const [isEditingContent, setIsEditingContent] = useState<boolean>(false);
   const [day, setDay] = useState<number>(1);
@@ -40,7 +67,9 @@ const useTemplateDetailsLogic = (id: string) => {
       const itinerariesResponse = await getItineraries(+id);
 
       if (response && itinerariesResponse) {
-        const itinerariesByDay = groupItinerariesByDay(itinerariesResponse.itineraries);
+        const itinerariesByDay = ensureDayKeys(
+          groupItinerariesByDay(itinerariesResponse.itineraries)
+        );
         setTitle(response.title);
         setContent(response.content);
         setRegionIds(response.regionIds);
@@ -62,14 +91,18 @@ const useTemplateDetailsLogic = (id: string) => {
   const addItinerary = useCallback((newItinerary: TemplateItinerary) => {
     const day = newItinerary.day;
     setItineraries((prev) => {
+      const baseDays = Object.keys(prev)
+        .map(Number)
+        .filter((value) => Number.isFinite(value));
       const dayItineraries = prev[day] || [];
-      const updatedDayItineraries = [...dayItineraries, newItinerary].sort((a, b) =>
-        a.startTime.localeCompare(b.startTime)
+      const updatedDayItineraries = [...dayItineraries, newItinerary].sort(
+        (a, b) => a.startTime.localeCompare(b.startTime)
       );
-      return {
+      const draft = {
         ...prev,
         [day]: updatedDayItineraries,
       };
+      return ensureDayKeys(draft, baseDays.includes(day) ? baseDays : [...baseDays, day]);
     });
   }, []);
 
@@ -80,13 +113,16 @@ const useTemplateDetailsLogic = (id: string) => {
   const updateItinerary = useCallback(
     (updatedItinerary: TemplateItinerary) => {
       setItineraries((prev) => {
+        const baseDays = Object.keys(prev)
+          .map(Number)
+          .filter((value) => Number.isFinite(value));
         const flatList = flattenItineraries(prev);
         const updatedList = flatList.map((item) =>
           item.id === updatedItinerary.id ? updatedItinerary : item
         );
         const newItineraries = groupItinerariesByDay(updatedList);
-        // Ensure a new object reference is created to trigger re-renders
-        return { ...newItineraries };
+
+        return ensureDayKeys(newItineraries, baseDays);
       });
     },
     []
@@ -98,13 +134,40 @@ const useTemplateDetailsLogic = (id: string) => {
    */
   const deleteItinerary = useCallback((itineraryId: number) => {
     setItineraries((prev) => {
+      const baseDays = Object.keys(prev)
+        .map(Number)
+        .filter((value) => Number.isFinite(value));
       const flatList = flattenItineraries(prev);
-      const updatedList = flatList.filter(
-        (item) => item.id !== itineraryId
-      );
-      return groupItinerariesByDay(updatedList);
+      const updatedList = flatList.filter((item) => item.id !== itineraryId);
+      const grouped = groupItinerariesByDay(updatedList);
+
+      return ensureDayKeys(grouped, baseDays);
     });
   }, []);
+
+  const addDay = useCallback(() => {
+    let nextDayValue = 1;
+    setItineraries((prev) => {
+      const baseDays = Object.keys(prev)
+        .map(Number)
+        .filter((value) => Number.isFinite(value));
+      const maxDay = baseDays.length === 0 ? 0 : Math.max(...baseDays);
+      nextDayValue = maxDay + 1;
+
+      if (prev[nextDayValue]) {
+        return prev;
+      }
+
+      const draft = {
+        ...prev,
+        [nextDayValue]: [],
+      };
+
+      return ensureDayKeys(draft, [...baseDays, nextDayValue]);
+    });
+    setDay(nextDayValue);
+    return nextDayValue;
+  }, [setDay]);
 
   useEffect(() => {
     const availableDays = Object.keys(itineraries)
@@ -148,6 +211,7 @@ const useTemplateDetailsLogic = (id: string) => {
     updateItinerary,
     deleteItinerary,
     refetch: fetchTemplateDetails,
+    addDay,
     setDay,
   };
 };

--- a/services/templates.ts
+++ b/services/templates.ts
@@ -2,6 +2,32 @@ import { templatesApi } from '@/api/templates';
 import { TemplateItineraryWithoutId } from '@/types/templates';
 import { isAxiosError } from 'axios';
 
+const TEMPLATE_CONFLICT_409_MESSAGE =
+  '현재 여행이 진행 중인 여행 계획은 수정할 수 없습니다!';
+
+const handleTemplateServiceError = (error: unknown, defaultMessage: string) => {
+  console.error(error);
+
+  if (isAxiosError(error)) {
+    const status = error.response?.status;
+
+    if (status === 409) {
+      throw new Error(TEMPLATE_CONFLICT_409_MESSAGE);
+    }
+
+    const apiMessage = error.response?.data?.message;
+    if (typeof apiMessage === 'string' && apiMessage.trim().length > 0) {
+      throw new Error(apiMessage);
+    }
+  }
+
+  if (error instanceof Error) {
+    throw error;
+  }
+
+  throw new Error(defaultMessage);
+};
+
 /**
  * 새로운 빈 여행 템플릿을 생성하고 생성된 템플릿의 ID를 반환합니다.
  * @returns 성공 시 생성된 템플릿의 ID, 실패 시 undefined
@@ -16,7 +42,7 @@ export const createBlankTemplate = async () => {
 
     throw new Error('템플릿 생성 에러');
   } catch (error) {
-    console.error(error);
+    handleTemplateServiceError(error, '템플릿 생성 에러');
   }
 };
 
@@ -36,7 +62,7 @@ export const setTemplateTitle = async (id: number, title: string) => {
 
     throw new Error('템플릿 제목 수정 에러');
   } catch (error) {
-    console.error(error);
+    handleTemplateServiceError(error, '템플릿 제목 수정 에러');
   }
 };
 
@@ -56,7 +82,7 @@ export const setTemplateContent = async (id: number, content: string) => {
 
     throw new Error('템플릿 본문 수정 에러');
   } catch (error) {
-    console.error(error);
+    handleTemplateServiceError(error, '템플릿 본문 수정 에러');
   }
 };
 
@@ -70,7 +96,7 @@ export const setTemplateImageUrls = async (id: number, imageUrls: string[]) => {
   if (imageUrls.length < 1) {
     return;
   }
-  
+
   try {
     const response = await templatesApi.setImages(id, imageUrls);
 
@@ -80,7 +106,7 @@ export const setTemplateImageUrls = async (id: number, imageUrls: string[]) => {
 
     throw new Error('템플릿 이미지 수정 에러');
   } catch (error) {
-    console.error(error);
+    handleTemplateServiceError(error, '템플릿 이미지 수정 에러');
   }
 };
 
@@ -100,7 +126,7 @@ export const setTemplateTags = async (id: number, tagIds: number[]) => {
 
     throw new Error('템플릿 태그 수정 에러');
   } catch (error) {
-    console.error(error);
+    handleTemplateServiceError(error, '템플릿 태그 수정 에러');
   }
 };
 
@@ -125,6 +151,9 @@ export const setTemplateItineraries = async (
   } catch (error) {
     if (isAxiosError(error)) {
       console.error(error.response?.data);
+      if (error.response?.status === 409) {
+        return { success: false, error: TEMPLATE_CONFLICT_409_MESSAGE };
+      }
       const errorMessage =
         error.response?.data?.message || '일정 저장 중 오류가 발생했습니다.';
       return { success: false, error: errorMessage };
@@ -151,7 +180,7 @@ export const setTemplateRegions = async (id: number, regionIds: number[]) => {
 
     throw new Error('템플릿 지역 수정 에러');
   } catch (error) {
-    console.error(error);
+    handleTemplateServiceError(error, '템플릿 지역 수정 에러');
   }
 };
 
@@ -245,6 +274,6 @@ export const deleteTemplate = async (id: number) => {
     const response = await templatesApi.deleteTemplate(id);
     return response;
   } catch (error) {
-    console.error(error);
+    handleTemplateServiceError(error, '템플릿 삭제 에러');
   }
 };

--- a/types/sessions.ts
+++ b/types/sessions.ts
@@ -1,4 +1,5 @@
 import APIResponse from './apiResponse';
+import { TemplateItinerary } from './templates';
 
 /**
  * 세션 생성 요청 데이터
@@ -167,15 +168,7 @@ interface SessionGetResponse extends APIResponse<SessionGetData> {
 /**
  * 세션 일정 정보 타입
  */
-interface SessionItinerary {
-  id: number;
-  day: number;
-  title: string;
-  content: string;
-  startTime: string; // HH:mm:ss 형식
-  latitude: number;
-  longitude: number;
-}
+type SessionItinerary = TemplateItinerary & { startDate: string }
 
 /**
  * 세션 일정 조회 요청 데이터 (빈 데이터)
@@ -281,5 +274,6 @@ export {
   SessionStatus,
   SessionUpdateData,
   SessionUpdateRequest,
-  SessionUpdateResponse,
+  SessionUpdateResponse
 };
+

--- a/types/templates.ts
+++ b/types/templates.ts
@@ -6,7 +6,7 @@ import APIResponse from "./apiResponse";
 interface TemplateItinerary {
   id: number;
   day: number;
-  title: string;
+  location: string;
   content: string;
   startTime: string;
   latitude: number;


### PR DESCRIPTION
## 이슈
- Closes #71
## 변경 내용
### 템플릿 편집 페이지
- 템플릿 편집 화면에서 제목 및 내용은 항상 편집 상태로 유지하며, 내용이 변경될 경우에만 저장 버튼을 활성화하도록 변경
- 상단 사진 영역 터치를 통해 사진 편집 가능하도록 변경. 기존 방식도 남겨져 있습니다.
### 템플릿 일정 편집 페이지
- 일정 항목의 제목을 '장소'로 변경하여, 편집 불가 처리 및 장소 선택 시 자동 입력되도록 변경
- 일정 편집 시 저장하지 않은 내용이 있는 상태에서 뒤로가기 시 경고
- 일정을 전부 삭제해 사라진 일차에 일차 선택 탭 포커싱이 유지되는 문제를 수정
- 일정 추가 시 일차 입력 영역을 텍스트인풋에서 증감 모달로 변경