### PR TITLE
Feature/#91 delete completed session

### DIFF
--- a/app/(app)/guide/home/index.tsx
+++ b/app/(app)/guide/home/index.tsx
@@ -1,15 +1,59 @@
 import CustomSafeAreaView from '@/components/CustomSafeAreaView';
 import { useAuth } from '@/hooks/useAuth';
+import { useSessionList } from '@/hooks/sessions/useSessionList';
+import { SessionInfo } from '@/types/sessions';
 import { Ionicons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
-import React from 'react';
-import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import React, { useMemo } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const GuideHomeScreen: React.FC = () => {
   const { user } = useAuth();
   const { bottom } = useSafeAreaInsets();
+  const { sessions, isLoading } = useSessionList();
+
+  // 날짜를 표시용 형식으로 변환 (예: 2024.01.15)
+  const formatDateForDisplay = (dateString: string): string => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}.${month}.${day}`;
+  };
+
+  // 모집 중인 세션만 필터링하고, 모집 인원이 가득 찬 순서대로 정렬한 후 최대 4개만 선택
+  const displayedSessions = useMemo(() => {
+    // 모집 중인 세션만 필터링 (RECRUITING, RECRUITMENT_CLOSED 상태)
+    const recruitingSessions = sessions.filter((session) =>
+      ['RECRUITING', 'RECRUITMENT_CLOSED'].includes(session.status)
+    );
+
+    // 모집 인원이 가득 찬 순서대로 정렬
+    const sortedSessions = [...recruitingSessions].sort((a, b) => {
+      const aIsFull = a.currentParticipants === a.maxParticipants;
+      const bIsFull = b.currentParticipants === b.maxParticipants;
+
+      // 가득 찬 세션이 먼저 오도록
+      if (aIsFull && !bIsFull) return -1;
+      if (!aIsFull && bIsFull) return 1;
+
+      // 둘 다 가득 찬 경우 또는 둘 다 가득 차지 않은 경우, 참여율이 높은 순서대로
+      const aRatio = a.currentParticipants / a.maxParticipants;
+      const bRatio = b.currentParticipants / b.maxParticipants;
+      return bRatio - aRatio;
+    });
+
+    // 최대 4개만 반환
+    return sortedSessions.slice(0, 4);
+  }, [sessions]);
   return (
     <CustomSafeAreaView>
       <View className='bg-gray-50'>
@@ -67,49 +111,85 @@ const GuideHomeScreen: React.FC = () => {
               <Text className='text-3xl font-bold text-gray-900'>
                 내 여행 모집
               </Text>
-              <TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => router.push('/guide/session')}
+              >
                 <Text className='text-purple-600 font-semibold'>더보기</Text>
               </TouchableOpacity>
             </View>
 
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerClassName='pr-2'
-            >
-              {/* 가이드 상품 리스트 */}
-              {[1, 2, 3, 4].map((item) => (
-                <TouchableOpacity
-                  key={item}
-                  className='bg-white rounded-2xl mr-3 overflow-hidden shadow-sm border border-gray-100'
-                  style={{ width: 180 }}
-                >
-                  <Image
-                    source={{ uri: 'https://via.placeholder.com/200' }}
-                    style={{ width: '100%', height: 120 }}
-                    contentFit='cover'
-                  />
-                  <View className='p-4'>
-                    <Text
-                      className='text-lg font-semibold text-gray-900 mb-2'
-                      numberOfLines={2}
-                    >
-                      홍대 1박2일 모임
-                    </Text>
-                    <View className='flex-row items-center'>
-                      <Ionicons
-                        name='calendar-outline'
-                        size={14}
-                        color='#6B7280'
-                      />
-                      <Text className='text-sm text-gray-600 ml-1'>
-                        2025.11.15
-                      </Text>
+            {isLoading ? (
+              <View className='py-8 items-center'>
+                <ActivityIndicator size='large' color='#8130FF' />
+              </View>
+            ) : displayedSessions.length > 0 ? (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerClassName='pr-2'
+              >
+                {/* 가이드 상품 리스트 */}
+                {displayedSessions.map((session) => (
+                  <TouchableOpacity
+                    key={session.sessionId}
+                    className='bg-white rounded-2xl mr-3 overflow-hidden shadow-sm border border-gray-100'
+                    style={{ width: 180 }}
+                    onPress={() =>
+                      router.push(
+                        `/guide/session/${session.sessionId}` as any
+                      )
+                    }
+                  >
+                    <View className='bg-gray-200' style={{ width: '100%', height: 120 }}>
+                      {session.firstImageUrl ? (
+                        <Image
+                          source={{ uri: session.firstImageUrl }}
+                          style={{ width: '100%', height: 120 }}
+                          contentFit='cover'
+                        />
+                      ) : (
+                        <View className='w-full h-full items-center justify-center'>
+                          <Ionicons name='image-outline' size={40} color='#9CA3AF' />
+                        </View>
+                      )}
                     </View>
-                  </View>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
+                    <View className='p-4'>
+                      <Text
+                        className='text-lg font-semibold text-gray-900 mb-2'
+                        numberOfLines={2}
+                      >
+                        {session.title || '제목 없음'}
+                      </Text>
+                      <View className='flex-row items-center justify-between'>
+                        <View className='flex-row items-center'>
+                          <Ionicons
+                            name='calendar-outline'
+                            size={14}
+                            color='#6B7280'
+                          />
+                          <Text className='text-sm text-gray-600 ml-1'>
+                            {formatDateForDisplay(session.startDate)}
+                          </Text>
+                        </View>
+                        {session.currentParticipants === session.maxParticipants && (
+                          <View className='px-2 py-0.5 rounded-full bg-purple-100'>
+                            <Text className='text-xs font-semibold text-purple-600'>
+                              모집완료
+                            </Text>
+                          </View>
+                        )}
+                      </View>
+                    </View>
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            ) : (
+              <View className='py-8 items-center'>
+                <Text className='text-gray-500 text-base'>
+                  모집 중인 여행이 없습니다
+                </Text>
+              </View>
+            )}
           </View>
 
           {/* 이달의 가이드 순위 섹션 */}

--- a/app/(app)/guide/session/index.tsx
+++ b/app/(app)/guide/session/index.tsx
@@ -2,12 +2,16 @@ import CustomSafeAreaView from '@/components/CustomSafeAreaView';
 import GuideSessionList from '@/components/guide/session/GuideSessionList';
 import { REGION_ID_TO_NAME_MAP } from '@/constants/Regions';
 import { useSessionList } from '@/hooks/sessions/useSessionList';
+import { cancelParticipation } from '@/services/sessions';
+import { SessionInfo } from '@/types/sessions';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
 import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
+  FlatList,
   RefreshControl,
   Text,
   TouchableOpacity,
@@ -78,6 +82,146 @@ const GuideTripListScreen: React.FC = () => {
           : ['COMPLETED', 'IN_PROGRESS'];
       refetch(statuses);
     }, [activeTab, refetch])
+  );
+
+  /**
+   * 세션 삭제 핸들러
+   */
+  const handleDeleteSession = useCallback(
+    async (sessionId: number) => {
+      Alert.alert('세션 삭제', '이 세션을 목록에서 삭제하시겠습니까?', [
+        {
+          text: '취소',
+          style: 'cancel',
+        },
+        {
+          text: '삭제',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await cancelParticipation(sessionId);
+              // 삭제 성공 시 목록 새로고침
+              refetch(['COMPLETED']);
+            } catch (error) {
+              Alert.alert('오류', '세션 삭제에 실패했습니다.');
+            }
+          },
+        },
+      ]);
+    },
+    [refetch]
+  );
+
+  /**
+   * 완료된 세션 아이템을 렌더링하는 함수
+   */
+  const renderCompletedSessionItem = useCallback(
+    ({ item: session }: { item: SessionInfo }) => {
+      const badgeStyle =
+        session.status === 'COMPLETED'
+          ? {
+              backgroundColor: '#DCFCE7',
+              textColor: '#15803D',
+              label: '완료',
+            }
+          : {
+              backgroundColor: '#F3F4F6',
+              textColor: '#4B5563',
+              label: '상태 미정',
+            };
+
+      const regionText =
+        (Array.isArray(session.regionIds) && session.regionIds.length > 0
+          ? session.regionIds.map((id: number) => REGION_ID_TO_NAME_MAP[id])
+          : (session as any).regionNames || []
+        )
+          .filter(Boolean)
+          .join(', ') || '지역 정보 없음';
+
+      return (
+        <View className='bg-white rounded-2xl mb-2 shadow-sm border border-gray-100 overflow-hidden'>
+          <TouchableOpacity
+            activeOpacity={0.7}
+            onPress={() => {
+              router.push(`/guide/session/${session.sessionId}` as any);
+            }}
+          >
+            <View className='p-5'>
+              <View className='flex-row items-center'>
+                <Image
+                  source={{ uri: session.firstImageUrl }}
+                  style={{
+                    width: 80,
+                    height: 80,
+                    borderRadius: 12,
+                    marginRight: 16,
+                  }}
+                  contentFit='cover'
+                />
+                <View className='flex-1'>
+                  <Text className='text-lg font-semibold text-gray-900 mb-1'>
+                    {session.title?.trim() || '제목 없음'}
+                  </Text>
+                  <Text className='text-gray-600 mb-2'>
+                    {session.startDate} ~ {session.endDate}
+                  </Text>
+                  <View className='flex-row items-start'>
+                    <MaterialIcons
+                      name='person-outline'
+                      size={16}
+                      color='#6B7280'
+                      style={{ marginTop: 2 }}
+                    />
+                    <Text className='text-gray-600 ml-1 mr-4'>
+                      {session.currentParticipants}/{session.maxParticipants}명
+                    </Text>
+                    <Ionicons
+                      name='location-outline'
+                      size={16}
+                      color='#6B7280'
+                      style={{ marginTop: 2 }}
+                    />
+                    <Text
+                      className='text-gray-600 ml-1 flex-1'
+                      numberOfLines={2}
+                      ellipsizeMode='tail'
+                    >
+                      {regionText}
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  className='px-3 py-1 rounded-full'
+                  style={{ backgroundColor: badgeStyle.backgroundColor }}
+                >
+                  <Text
+                    className='text-sm font-medium'
+                    style={{ color: badgeStyle.textColor }}
+                  >
+                    {badgeStyle.label}
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </TouchableOpacity>
+
+          {/* 완료된 세션 하단 삭제 버튼 */}
+          <View className='px-5 pb-5 border-t border-gray-100'>
+            <TouchableOpacity
+              className='bg-red-500 rounded-xl py-3 flex-row items-center justify-center'
+              onPress={() => handleDeleteSession(session.sessionId)}
+              activeOpacity={0.8}
+            >
+              <Ionicons name='trash-outline' size={20} color='#fff' />
+              <Text className='text-white font-semibold text-base ml-2'>
+                세션 삭제
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      );
+    },
+    [handleDeleteSession, router]
   );
 
   /**
@@ -253,16 +397,15 @@ const GuideTripListScreen: React.FC = () => {
                   : '완료된 여행이 없습니다.'}
               </Text>
             </View>
-          ) : (
-            <GuideSessionList
-              userRole='GUIDE'
-              sessions={filteredSessions}
+          ) : activeTab === 'completed' ? (
+            // 완료 탭일 때는 삭제 버튼이 있는 직접 렌더링
+            <FlatList
+              data={filteredSessions}
+              renderItem={renderCompletedSessionItem}
+              keyExtractor={(item) => item.sessionId.toString()}
+              showsVerticalScrollIndicator={false}
               onEndReached={() => {
-                const statuses =
-                  activeTab === 'ongoing'
-                    ? ['RECRUITING', 'RECRUITMENT_CLOSED', 'IN_PROGRESS']
-                    : ['COMPLETED', 'IN_PROGRESS'];
-                loadMore(statuses);
+                loadMore(['COMPLETED']);
               }}
               onEndReachedThreshold={0.5}
               ListFooterComponent={renderFooter}
@@ -270,11 +413,31 @@ const GuideTripListScreen: React.FC = () => {
                 <RefreshControl
                   refreshing={isLoading && filteredSessions.length > 0}
                   onRefresh={() => {
-                    const statuses =
-                      activeTab === 'ongoing'
-                        ? ['RECRUITING', 'RECRUITMENT_CLOSED', 'IN_PROGRESS']
-                        : ['COMPLETED', 'IN_PROGRESS'];
-                    refetch(statuses);
+                    refetch(['COMPLETED']);
+                  }}
+                />
+              }
+              contentContainerStyle={{ paddingBottom: bottom }}
+            />
+          ) : (
+            // 모집 중 탭일 때는 기존 GuideSessionList 사용
+            <GuideSessionList
+              userRole='GUIDE'
+              sessions={filteredSessions}
+              onEndReached={() => {
+                loadMore(['RECRUITING', 'RECRUITMENT_CLOSED', 'IN_PROGRESS']);
+              }}
+              onEndReachedThreshold={0.5}
+              ListFooterComponent={renderFooter}
+              refreshControl={
+                <RefreshControl
+                  refreshing={isLoading && filteredSessions.length > 0}
+                  onRefresh={() => {
+                    refetch([
+                      'RECRUITING',
+                      'RECRUITMENT_CLOSED',
+                      'IN_PROGRESS',
+                    ]);
                   }}
                 />
               }

--- a/app/(app)/guide/session/index.tsx
+++ b/app/(app)/guide/session/index.tsx
@@ -106,7 +106,7 @@ const GuideTripListScreen: React.FC = () => {
                 // 삭제 성공 시 목록 새로고침
                 refetch(['COMPLETED']);
               } catch (error) {
-                Alert.alert('오류', '세션 삭제에 실패했습니다.');
+                Alert.alert('오류', '여행 기록 삭제에 실패했습니다.');
               }
             },
           },

--- a/app/(app)/guide/session/index.tsx
+++ b/app/(app)/guide/session/index.tsx
@@ -89,25 +89,29 @@ const GuideTripListScreen: React.FC = () => {
    */
   const handleDeleteSession = useCallback(
     async (sessionId: number) => {
-      Alert.alert('세션 삭제', '이 세션을 목록에서 삭제하시겠습니까?', [
-        {
-          text: '취소',
-          style: 'cancel',
-        },
-        {
-          text: '삭제',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await cancelParticipation(sessionId);
-              // 삭제 성공 시 목록 새로고침
-              refetch(['COMPLETED']);
-            } catch (error) {
-              Alert.alert('오류', '세션 삭제에 실패했습니다.');
-            }
+      Alert.alert(
+        '여행 기록 삭제',
+        '이 여행을 목록에서 삭제하시겠습니까?\n삭제 후 복구가 불가능합니다.',
+        [
+          {
+            text: '취소',
+            style: 'cancel',
           },
-        },
-      ]);
+          {
+            text: '삭제',
+            style: 'destructive',
+            onPress: async () => {
+              try {
+                await cancelParticipation(sessionId);
+                // 삭제 성공 시 목록 새로고침
+                refetch(['COMPLETED']);
+              } catch (error) {
+                Alert.alert('오류', '세션 삭제에 실패했습니다.');
+              }
+            },
+          },
+        ]
+      );
     },
     [refetch]
   );
@@ -214,7 +218,7 @@ const GuideTripListScreen: React.FC = () => {
             >
               <Ionicons name='trash-outline' size={20} color='#fff' />
               <Text className='text-white font-semibold text-base ml-2'>
-                세션 삭제
+                여행 기록 삭제
               </Text>
             </TouchableOpacity>
           </View>

--- a/app/(app)/guide/template/[id]/edit-itinerary.tsx
+++ b/app/(app)/guide/template/[id]/edit-itinerary.tsx
@@ -20,6 +20,7 @@ import {
   UIManager,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 
 // Enable LayoutAnimation for Android
@@ -46,6 +47,7 @@ const EditTemplateItineraryScreen: React.FC = () => {
   const router = useRouter();
   const params = useLocalSearchParams<ItineraryParamProps>();
   const { updateItinerary, setDay } = useTemplateDetails();
+  const insets = useSafeAreaInsets();
 
   const parseDay = (dayParam?: string) => {
     const parsed = parseInt(dayParam ?? '', 10);
@@ -166,9 +168,16 @@ const EditTemplateItineraryScreen: React.FC = () => {
     toggleMapExpansion(false);
   };
 
+  // 헤더 높이를 고려한 keyboardVerticalOffset 계산 (헤더: paddingTop 12 + paddingBottom 10 + 아이콘/텍스트 높이 약 30)
+  const headerHeight = 52;
+  const keyboardVerticalOffset =
+    Platform.OS === 'ios' ? insets.top + headerHeight : headerHeight;
+
   return (
     <CustomSafeAreaView>
-      <CustomKeyboardAvoidingView>
+      <CustomKeyboardAvoidingView
+        keyboardVerticalOffset={keyboardVerticalOffset}
+      >
         <View style={styles.container}>
           {!isMapExpanded && (
             <View style={styles.header}>
@@ -231,7 +240,11 @@ const EditTemplateItineraryScreen: React.FC = () => {
           </View>
 
           {!isMapExpanded && (
-            <ScrollView contentContainerStyle={styles.scrollViewContent}>
+            <ScrollView
+              contentContainerStyle={styles.scrollViewContent}
+              keyboardShouldPersistTaps='handled'
+              keyboardDismissMode='interactive'
+            >
               <View style={styles.infoRow}>
                 <View style={styles.dayInfoWrapper}>
                   <View style={styles.dayInfoContainer}>

--- a/app/(app)/guide/template/[id]/edit-regions.tsx
+++ b/app/(app)/guide/template/[id]/edit-regions.tsx
@@ -31,10 +31,11 @@ const EditTemplateRegionsScreen: React.FC = () => {
     useState<number[]>(regionIds);
   const [isSaving, setIsSaving] = useState(false);
 
-  const showToast = () => {
+  const showToast = (errorMessage?: string) => {
     Toast.show({
       type: 'error',
       text1: '지역 수정 중 오류가 발생했습니다.',
+      text2: errorMessage || undefined,
     });
   };
 
@@ -75,7 +76,9 @@ const EditTemplateRegionsScreen: React.FC = () => {
       router.back();
     } catch (error) {
       console.error(error);
-      showToast();
+      const errorMessage =
+        error instanceof Error ? error.message : undefined;
+      showToast(errorMessage);
     } finally {
       setIsSaving(false);
     }

--- a/app/(app)/traveler/home/index.tsx
+++ b/app/(app)/traveler/home/index.tsx
@@ -1,12 +1,69 @@
 import CustomSafeAreaView from '@/components/CustomSafeAreaView';
 import { useAuth } from '@/hooks/useAuth';
+import { searchSessions } from '@/services/sessions';
+import { SessionInfo } from '@/types/sessions';
 import { Ionicons } from '@expo/vector-icons';
+import { Image } from 'expo-image';
 import { router } from 'expo-router';
-import React from 'react';
-import { Image, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image as RNImage,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 const TravelerHomeScreen: React.FC = () => {
   const { user } = useAuth();
+  const [recommendedSessions, setRecommendedSessions] = useState<
+    SessionInfo[]
+  >([]);
+  const [isLoadingRecommended, setIsLoadingRecommended] = useState(false);
+
+  // 날짜를 표시용 형식으로 변환 (예: 2024.01.15)
+  const formatDateForDisplay = (dateString: string): string => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}.${month}.${day}`;
+  };
+
+  // 사용자의 관심사 기반으로 맞춤 여행 조회
+  useEffect(() => {
+    const fetchRecommendedSessions = async () => {
+      if (!user?.tagIds || user.tagIds.length === 0) {
+        return;
+      }
+
+      setIsLoadingRecommended(true);
+      try {
+        const response = await searchSessions(
+          undefined, // keyword
+          undefined, // searchStartDate
+          undefined, // searchEndDate
+          undefined, // regionIds
+          user.tagIds, // tagIds - 사용자의 관심사 태그
+          0, // page
+          4 // size - 최대 4개까지
+        );
+
+        if (response && response.sessions) {
+          // 최대 4개까지만 표시
+          setRecommendedSessions(response.sessions.slice(0, 4));
+        }
+      } catch (error) {
+        console.error('맞춤 여행 조회 에러:', error);
+      } finally {
+        setIsLoadingRecommended(false);
+      }
+    };
+
+    fetchRecommendedSessions();
+  }, [user?.tagIds]);
+
   return (
     <CustomSafeAreaView>
       <View className='flex-1 bg-gray-50'>
@@ -19,7 +76,7 @@ const TravelerHomeScreen: React.FC = () => {
           >
             <View className='w-10 h-10 rounded-full bg-gray-200 justify-center items-center'>
               {user?.profileImageUrl ? (
-                <Image
+                <RNImage
                   source={{ uri: user.profileImageUrl }}
                   style={{ width: 40, height: 40, borderRadius: 20 }}
                 />
@@ -63,48 +120,76 @@ const TravelerHomeScreen: React.FC = () => {
               <Text className='text-3xl font-bold text-gray-900'>
                 맞춤 여행 추천
               </Text>
-              <TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => router.push('/traveler/explore')}
+              >
                 <Text className='text-blue-600 font-semibold'>더보기</Text>
               </TouchableOpacity>
             </View>
 
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerClassName='pr-2'
-            >
-              {/* 추천 상품 리스트 */}
-              {[1, 2, 3, 4].map((item) => (
-                <TouchableOpacity
-                  key={item}
-                  className='bg-white rounded-2xl mr-3 overflow-hidden shadow-sm border border-gray-100'
-                  style={{ width: 180 }}
-                >
-                  <Image
-                    source={{ uri: 'https://via.placeholder.com/200' }}
-                    style={{ width: '100%', height: 120 }}
-                  />
-                  <View className='p-4'>
-                    <Text
-                      className='text-lg font-semibold text-gray-900 mb-2'
-                      numberOfLines={2}
-                    >
-                      서울 도심 탐방 패키지
-                    </Text>
-                    <View className='flex-row items-center'>
-                      <Ionicons
-                        name='calendar-outline'
-                        size={14}
-                        color='#6B7280'
-                      />
-                      <Text className='text-sm text-gray-600 ml-1'>
-                        2024.01.15
-                      </Text>
+            {isLoadingRecommended ? (
+              <View className='py-8 items-center'>
+                <ActivityIndicator size='large' color='#3B82F6' />
+              </View>
+            ) : recommendedSessions.length > 0 ? (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerClassName='pr-2'
+              >
+                {/* 추천 상품 리스트 */}
+                {recommendedSessions.map((session) => (
+                  <TouchableOpacity
+                    key={session.sessionId}
+                    className='bg-white rounded-2xl mr-3 overflow-hidden shadow-sm border border-gray-100'
+                    style={{ width: 180 }}
+                    onPress={() =>
+                      router.push(
+                        `/traveler/trip/${session.sessionId}` as any
+                      )
+                    }
+                  >
+                    <View className='bg-gray-200' style={{ width: '100%', height: 120 }}>
+                      {session.firstImageUrl ? (
+                        <Image
+                          source={{ uri: session.firstImageUrl }}
+                          style={{ width: '100%', height: 120 }}
+                          contentFit='cover'
+                        />
+                      ) : (
+                        <View className='w-full h-full items-center justify-center'>
+                          <Ionicons name='image-outline' size={40} color='#9CA3AF' />
+                        </View>
+                      )}
                     </View>
-                  </View>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
+                    <View className='p-4'>
+                      <Text
+                        className='text-lg font-semibold text-gray-900 mb-2'
+                        numberOfLines={2}
+                      >
+                        {session.title}
+                      </Text>
+                      <View className='flex-row items-center'>
+                        <Ionicons
+                          name='calendar-outline'
+                          size={14}
+                          color='#6B7280'
+                        />
+                        <Text className='text-sm text-gray-600 ml-1'>
+                          {formatDateForDisplay(session.startDate)}
+                        </Text>
+                      </View>
+                    </View>
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            ) : (
+              <View className='py-8 items-center'>
+                <Text className='text-gray-500 text-base'>
+                  관심사에 맞는 여행을 찾을 수 없습니다
+                </Text>
+              </View>
+            )}
           </View>
 
           {/* 이달의 가이드 순위 섹션 */}

--- a/app/(app)/traveler/trip/index.tsx
+++ b/app/(app)/traveler/trip/index.tsx
@@ -183,7 +183,7 @@ const TravelerTripListScreen: React.FC = () => {
                 // 삭제 성공 시 목록 새로고침
                 refetchCompleted();
               } catch (error) {
-                Alert.alert('오류', '세션 삭제에 실패했습니다.');
+                Alert.alert('오류', '여행 기록 삭제에 실패했습니다.');
               }
             },
           },

--- a/app/(app)/traveler/trip/index.tsx
+++ b/app/(app)/traveler/trip/index.tsx
@@ -52,8 +52,14 @@ const TravelerTripListScreen: React.FC = () => {
     (tab: 'upcoming' | 'completed') => {
       setActiveTab(tab);
       if (tab === 'upcoming') {
-        refetchParticipating(['RECRUITING', 'RECRUITMENT_CLOSED']);
+        refetchParticipating([
+          'RECRUITING',
+          'RECRUITMENT_CLOSED',
+          'IN_PROGRESS',
+        ]);
       } else {
+        // 완료 탭일 때도 진행 중인 여행을 조회하기 위해 participatingSessions도 새로고침
+        refetchParticipating(['IN_PROGRESS']);
         refetchCompleted();
       }
     },
@@ -94,15 +100,13 @@ const TravelerTripListScreen: React.FC = () => {
     return filtered;
   }, [sessions, activeTab]);
 
-  // 현재 진행 중인 세션 (IN_PROGRESS 상태) - 예정 탭에서만 사용
+  // 현재 진행 중인 세션 (IN_PROGRESS 상태) - 탭과 관계없이 항상 표시
   const currentSession = useMemo(() => {
-    if (activeTab === 'upcoming') {
-      return participatingSessions.find(
-        (session) => session.status === 'IN_PROGRESS'
-      );
-    }
-    return undefined;
-  }, [participatingSessions, activeTab]);
+    // 탭과 관계없이 항상 participatingSessions에서 진행 중인 세션 찾기
+    return participatingSessions.find(
+      (session) => session.status === 'IN_PROGRESS'
+    );
+  }, [participatingSessions]);
 
   // 화면 포커스 시 데이터 새로고침
   useFocusEffect(
@@ -114,6 +118,8 @@ const TravelerTripListScreen: React.FC = () => {
           'IN_PROGRESS',
         ]);
       } else {
+        // 완료 탭일 때도 진행 중인 여행을 조회하기 위해 participatingSessions도 새로고침
+        refetchParticipating(['IN_PROGRESS']);
         refetchCompleted();
       }
     }, [activeTab, refetchParticipating, refetchCompleted])
@@ -501,7 +507,11 @@ const TravelerTripListScreen: React.FC = () => {
                 showsVerticalScrollIndicator={false}
                 onEndReached={() => {
                   if (activeTab === 'upcoming') {
-                    loadMoreParticipating(['RECRUITING', 'RECRUITMENT_CLOSED']);
+                    loadMoreParticipating([
+                      'RECRUITING',
+                      'RECRUITMENT_CLOSED',
+                      'IN_PROGRESS',
+                    ]);
                   } else {
                     loadMoreCompleted();
                   }

--- a/app/(app)/traveler/trip/index.tsx
+++ b/app/(app)/traveler/trip/index.tsx
@@ -166,25 +166,29 @@ const TravelerTripListScreen: React.FC = () => {
    */
   const handleDeleteSession = useCallback(
     async (sessionId: number) => {
-      Alert.alert('세션 삭제', '이 세션을 목록에서 삭제하시겠습니까?', [
-        {
-          text: '취소',
-          style: 'cancel',
-        },
-        {
-          text: '삭제',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await cancelParticipation(sessionId);
-              // 삭제 성공 시 목록 새로고침
-              refetchCompleted();
-            } catch (error) {
-              Alert.alert('오류', '세션 삭제에 실패했습니다.');
-            }
+      Alert.alert(
+        '여행 기록 삭제',
+        '이 여행을 목록에서 삭제하시겠습니까?\n삭제 후 복구가 불가능합니다.',
+        [
+          {
+            text: '취소',
+            style: 'cancel',
           },
-        },
-      ]);
+          {
+            text: '삭제',
+            style: 'destructive',
+            onPress: async () => {
+              try {
+                await cancelParticipation(sessionId);
+                // 삭제 성공 시 목록 새로고침
+                refetchCompleted();
+              } catch (error) {
+                Alert.alert('오류', '세션 삭제에 실패했습니다.');
+              }
+            },
+          },
+        ]
+      );
     },
     [refetchCompleted]
   );
@@ -312,7 +316,7 @@ const TravelerTripListScreen: React.FC = () => {
             >
               <Ionicons name='trash-outline' size={20} color='#fff' />
               <Text className='text-white font-semibold text-base ml-2'>
-                세션 삭제
+                여행 기록 삭제
               </Text>
             </TouchableOpacity>
           </View>

--- a/app/(app)/traveler/trip/index.tsx
+++ b/app/(app)/traveler/trip/index.tsx
@@ -2,6 +2,7 @@ import CustomSafeAreaView from '@/components/CustomSafeAreaView';
 import { REGION_ID_TO_NAME_MAP } from '@/constants/Regions';
 import { useCompletedSessionList } from '@/hooks/sessions/useCompletedSessionList';
 import { useParticipatingSessionList } from '@/hooks/sessions/useParticipatingSessionList';
+import { cancelParticipation } from '@/services/sessions';
 import { SessionCompletedInfo, SessionInfo } from '@/types/sessions';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
@@ -9,6 +10,7 @@ import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   FlatList,
   RefreshControl,
   Text,
@@ -154,6 +156,34 @@ const TravelerTripListScreen: React.FC = () => {
   };
 
   /**
+   * 세션 삭제 핸들러
+   */
+  const handleDeleteSession = useCallback(
+    async (sessionId: number) => {
+      Alert.alert('세션 삭제', '이 세션을 목록에서 삭제하시겠습니까?', [
+        {
+          text: '취소',
+          style: 'cancel',
+        },
+        {
+          text: '삭제',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await cancelParticipation(sessionId);
+              // 삭제 성공 시 목록 새로고침
+              refetchCompleted();
+            } catch (error) {
+              Alert.alert('오류', '세션 삭제에 실패했습니다.');
+            }
+          },
+        },
+      ]);
+    },
+    [refetchCompleted]
+  );
+
+  /**
    * 세션 아이템을 렌더링하는 함수
    */
   const renderSessionItem = ({
@@ -247,22 +277,36 @@ const TravelerTripListScreen: React.FC = () => {
           </View>
         </TouchableOpacity>
 
-        {/* 완료된 세션 중 리뷰를 작성한 적이 없는 경우에만 리뷰 버튼 표시 */}
-        {isCompleted && !hasWrittenReview && (
+        {/* 완료된 세션 하단 버튼들 */}
+        {isCompleted && (
           <View className='px-5 pb-5 border-t border-gray-100'>
+            {/* 리뷰를 작성한 적이 없는 경우 리뷰 버튼 표시 */}
+            {!hasWrittenReview && (
+              <TouchableOpacity
+                className='bg-purple-500 rounded-xl py-3 flex-row items-center justify-center mb-2'
+                onPress={() =>
+                  router.push({
+                    pathname: '/ReviewWriteScreen',
+                    params: { sessionId: session.sessionId.toString() },
+                  } as any)
+                }
+                activeOpacity={0.8}
+              >
+                <Ionicons name='star' size={20} color='#fff' />
+                <Text className='text-white font-semibold text-base ml-2'>
+                  리뷰 작성하기
+                </Text>
+              </TouchableOpacity>
+            )}
+            {/* 세션 삭제 버튼 */}
             <TouchableOpacity
-              className='bg-purple-500 rounded-xl py-3 flex-row items-center justify-center'
-              onPress={() =>
-                router.push({
-                  pathname: '/ReviewWriteScreen',
-                  params: { sessionId: session.sessionId.toString() },
-                } as any)
-              }
+              className='bg-red-500 rounded-xl py-3 flex-row items-center justify-center'
+              onPress={() => handleDeleteSession(session.sessionId)}
               activeOpacity={0.8}
             >
-              <Ionicons name='star' size={20} color='#fff' />
+              <Ionicons name='trash-outline' size={20} color='#fff' />
               <Text className='text-white font-semibold text-base ml-2'>
-                리뷰 작성하기
+                세션 삭제
               </Text>
             </TouchableOpacity>
           </View>

--- a/components/CustomKeyboardAvoidingView.tsx
+++ b/components/CustomKeyboardAvoidingView.tsx
@@ -1,16 +1,27 @@
 import React from 'react';
-import { KeyboardAvoidingView, KeyboardAvoidingViewProps, Platform, StyleSheet } from 'react-native';
+import {
+  KeyboardAvoidingView,
+  KeyboardAvoidingViewProps,
+  Platform,
+  StyleSheet,
+} from 'react-native';
 
 interface CustomKeyboardAvoidingViewProps extends KeyboardAvoidingViewProps {
   children: React.ReactNode;
 }
 
-const CustomKeyboardAvoidingView: React.FC<CustomKeyboardAvoidingViewProps> = ({ children, ...rest }) => {
+const CustomKeyboardAvoidingView: React.FC<CustomKeyboardAvoidingViewProps> = ({
+  children,
+  keyboardVerticalOffset,
+  ...rest
+}) => {
   return (
     <KeyboardAvoidingView
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       style={styles.container}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
+      keyboardVerticalOffset={
+        keyboardVerticalOffset ?? (Platform.OS === 'ios' ? 0 : 0)
+      }
       {...rest}
     >
       {children}

--- a/components/session/SessionDetailScreen.tsx
+++ b/components/session/SessionDetailScreen.tsx
@@ -338,7 +338,7 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
             Toast.show({
               type: 'error',
               text1: '참여 신청 실패',
-              text2: '본인의 여행 또는 이미 신청한 여행입니다',
+              text2: '다른 날짜에 참여 중인 여행이 있는지 확인해 주세요.',
             });
           } finally {
             setIsSubmitting(false);

--- a/components/session/SessionDetailScreen.tsx
+++ b/components/session/SessionDetailScreen.tsx
@@ -470,44 +470,48 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
   const handleDeleteSession = useCallback(async () => {
     if (!id) return;
 
-    Alert.alert('여행 삭제', '정말로 이 여행을 삭제하시겠습니까?', [
-      {
-        text: '취소',
-        style: 'cancel',
-      },
-      {
-        text: '삭제',
-        style: 'destructive',
-        onPress: async () => {
-          try {
-            const success = await deleteSession(parseInt(id));
-            if (success) {
-              Toast.show({
-                type: 'success',
-                text1: '여행이 삭제되었습니다.',
-              });
-              // 공통 네비게이션 핸들러 사용
-              const handled = handleNavigateBack();
-              if (!handled) {
-                router.back();
+    Alert.alert(
+      '여행 기록 삭제',
+      '이 여행을 목록에서 삭제하시겠습니까?\n삭제 후 복구가 불가능합니다.',
+      [
+        {
+          text: '취소',
+          style: 'cancel',
+        },
+        {
+          text: '삭제',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              const success = await deleteSession(parseInt(id));
+              if (success) {
+                Toast.show({
+                  type: 'success',
+                  text1: '여행이 삭제되었습니다.',
+                });
+                // 공통 네비게이션 핸들러 사용
+                const handled = handleNavigateBack();
+                if (!handled) {
+                  router.back();
+                }
+              } else {
+                Toast.show({
+                  type: 'error',
+                  text1: '여행 삭제에 실패했습니다.',
+                });
               }
-            } else {
+            } catch (error) {
+              console.error('여행 삭제 에러:', error);
               Toast.show({
                 type: 'error',
-                text1: '여행 삭제에 실패했습니다.',
+                text1: '여행 삭제 중 오류가 발생했습니다.',
+                text2: '잠시 후 다시 시도해주세요.',
               });
             }
-          } catch (error) {
-            console.error('여행 삭제 에러:', error);
-            Toast.show({
-              type: 'error',
-              text1: '여행 삭제 중 오류가 발생했습니다.',
-              text2: '잠시 후 다시 시도해주세요.',
-            });
-          }
+          },
         },
-      },
-    ]);
+      ]
+    );
   }, [id, router, handleNavigateBack]);
 
   // 섹션으로 스크롤

--- a/components/session/SessionDetailScreen.tsx
+++ b/components/session/SessionDetailScreen.tsx
@@ -1208,7 +1208,10 @@ const SessionDetailContent: React.FC<SessionDetailScreenProps> = ({
               <TouchableOpacity
                 style={[styles.ctaButton, styles.primaryButton]}
                 onPress={() => {
-                  router.push('/ReviewWriteScreen' as any);
+                  router.push({
+                    pathname: '/ReviewWriteScreen',
+                    params: { sessionId: id },
+                  } as any);
                 }}
               >
                 <Text style={styles.primaryButtonText}>리뷰 작성</Text>


### PR DESCRIPTION
## 이슈
- Closes #91 
## 내용
- 내가 참여하여 완료한 여행을 삭제 기능 추가
실제로는 '참여 취소'와 동일한 기능이며, 가이드의 경우 참여 취소 처리 이후에도 완료 여행 목록에 해당 여행이 남는 문제가 있습니다. (백엔드 이슈)
- 여행자/가이드의 홈 화면에 각각 '맞춤 여행 추천'과 '내 모집' 섹션 구현
여행자는 자신이 설정한 관심사를 하나라도 포함하는 모집 중 여행을 보여주며, 가이드는 자신이 개설한 여행을 모집인원이 존재하는 것을 우선하여 보여줍니다. 더보기를 통해 '탐색' 또는 '내 여행' 탭으로 이동할 수 있지만 탐색 탭에 자동으로 관심사 태그가 적용된다거나 하지는 않습니다.
- 기타 오류 메시지, 텍스트, 라우팅 등의 오류 수정